### PR TITLE
Fix shell history null pointer

### DIFF
--- a/subsys/shell/shell_history.c
+++ b/subsys/shell/shell_history.c
@@ -79,9 +79,9 @@ bool z_shell_history_get(struct shell_history *history, bool up,
 	}
 
 	history->current = l_item;
-	h_item = CONTAINER_OF(l_item, struct shell_history_item, dnode);
 
 	if (l_item) {
+		h_item = CONTAINER_OF(l_item, struct shell_history_item, dnode);
 		memcpy(dst, h_item->data, h_item->len);
 		*len = h_item->len;
 		dst[*len] = '\0';
@@ -155,7 +155,8 @@ void z_shell_history_put(struct shell_history *history, uint8_t *line,
 	}
 
 	l_item = sys_dlist_peek_head(&history->list);
-	h_prev_item = CONTAINER_OF(l_item, struct shell_history_item, dnode);
+	h_prev_item = l_item ?
+		CONTAINER_OF(l_item, struct shell_history_item, dnode) : NULL;
 
 	if (l_item &&
 	   (h_prev_item->len == len) &&


### PR DESCRIPTION
## Summary
- fix `container_of(NULL)` cases in shell history logic

## Testing
- `scripts/checkpatch.pl -f subsys/shell/shell_history.c`
- `scripts/twister -T tests/subsys/shell/shell_history -vv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684ddb77c3d88321b3af6f1e054fa696