### PR TITLE
Fix MQTT transport error handling

### DIFF
--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -193,8 +193,8 @@ static int pack_variable_int(uint32_t value, struct buf_ctx *buf)
  * @retval 0 if the procedure is successful.
  * @retval -EMSGSIZE if the message is too big for MQTT.
  */
-static uint32_t mqtt_encode_fixed_header(uint8_t message_type, uint8_t *start,
-				      struct buf_ctx *buf)
+static int mqtt_encode_fixed_header(uint8_t message_type, uint8_t *start,
+                                    struct buf_ctx *buf)
 {
 	uint32_t length = buf->cur - start;
 	uint8_t fixed_header_length;

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
@@ -41,9 +41,9 @@ int mqtt_client_tcp_connect(struct mqtt_client *client)
 				       SO_BINDTODEVICE, &ifname,
 				       sizeof(struct ifreq));
 		if (ret < 0) {
-			NET_ERR("Failed to bind ot interface %s error (%d)",
-				ifname.ifr_name, -errno);
-			goto error;
+        NET_ERR("Failed to bind to interface %s error (%d)",
+                ifname.ifr_name, -errno);
+        goto error;
 		}
 
 		NET_DBG("Bound to interface %s", ifname.ifr_name);
@@ -77,8 +77,9 @@ int mqtt_client_tcp_connect(struct mqtt_client *client)
 	return 0;
 
 error:
-	(void)zsock_close(client->transport.tcp.sock);
-	return -errno;
+        ret = -errno;
+        (void)zsock_close(client->transport.tcp.sock);
+        return ret;
 }
 
 int mqtt_client_tcp_write(struct mqtt_client *client, const uint8_t *data,

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -42,9 +42,9 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 				       SO_BINDTODEVICE, &ifname,
 				       sizeof(struct ifreq));
 		if (ret < 0) {
-			NET_ERR("Failed to bind ot interface %s error (%d)",
-				ifname.ifr_name, -errno);
-			goto error;
+        NET_ERR("Failed to bind to interface %s error (%d)",
+                ifname.ifr_name, -errno);
+        goto error;
 		}
 
 		NET_DBG("Bound to interface %s", ifname.ifr_name);
@@ -134,8 +134,9 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 	return 0;
 
 error:
-	(void) zsock_close(client->transport.tls.sock);
-	return -errno;
+        ret = -errno;
+        (void) zsock_close(client->transport.tls.sock);
+        return ret;
 }
 
 int mqtt_client_tls_write(struct mqtt_client *client, const uint8_t *data,


### PR DESCRIPTION
## Summary
- fix typo and preserve errno when mqtt transport fails
- make mqtt_encode_fixed_header return signed int

## Testing
- `scripts/twister -T tests/net/lib/mqtt/v3_1_1/mqtt_client -p native_sim --inline-logs -v` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684ddbc6d2e4832181340c4059d75cd8