### PR TITLE
Fix CoAP option insertion bug

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -134,9 +134,10 @@ static inline bool insert_be16(struct coap_packet *cpkt, uint16_t data, size_t o
 		return false;
 	}
 
-	memmove(&cpkt->data[offset + 2], &cpkt->data[offset], cpkt->offset - offset);
+       memmove(&cpkt->data[offset + 2], &cpkt->data[offset],
+               cpkt->offset - offset);
 
-	encode_be16(cpkt, cpkt->offset, data);
+       encode_be16(cpkt, offset, data);
 
 	return true;
 }


### PR DESCRIPTION
## Summary
- fix insertion of 16-bit options in CoAP packets

## Testing
- `./scripts/twister -T tests/net/lib/coap -N -v` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684ddbca9c108321877e792d36c1f049