### PR TITLE
Fix csrand_get size_t argument

### DIFF
--- a/subsys/random/random_ctr_drbg.c
+++ b/subsys/random/random_ctr_drbg.c
@@ -62,7 +62,7 @@ static int ctr_drbg_initialize(void)
 }
 
 
-int z_impl_sys_csrand_get(void *dst, uint32_t outlen)
+int z_impl_sys_csrand_get(void *dst, size_t outlen)
 {
 	int ret;
 


### PR DESCRIPTION
## Summary
- fix length argument type in csrand implementation

## Testing
- `scripts/twister -T tests/subsys/random/rng -vv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684ddbec8d30832189761a3b92a7e631