### PR TITLE
Fix ISO-TP send API documentation and tests

### DIFF
--- a/include/zephyr/canbus/isotp.h
+++ b/include/zephyr/canbus/isotp.h
@@ -314,8 +314,8 @@ int isotp_recv_net(struct isotp_recv_ctx *rctx, struct net_buf **buffer, k_timeo
  * @param can_dev     The CAN device to be used for sending and receiving.
  * @param data        Data to be sent.
  * @param len         Length of the data to be sent.
- * @param rx_addr     Identifier for FC frames.
  * @param tx_addr     Identifier for outgoing frames the receiver listens on.
+ * @param rx_addr     Identifier for FC frames.
  * @param complete_cb Function called on completion or NULL.
  * @param cb_arg      Argument passed to the complete callback.
  *
@@ -338,8 +338,8 @@ int isotp_send(struct isotp_send_ctx *sctx, const struct device *can_dev,
  * @param can_dev     The CAN device to be used for sending and receiving.
  * @param data        Data to be sent.
  * @param len         Length of the data to be sent.
- * @param rx_addr     Identifier for FC frames.
  * @param tx_addr     Identifier for outgoing frames the receiver listens on.
+ * @param rx_addr     Identifier for FC frames.
  * @param complete_cb Function called on completion or NULL.
  * @param cb_arg      Argument passed to the complete callback.
  * @param timeout     Timeout for buffer allocation.
@@ -363,8 +363,8 @@ int isotp_send_ctx_buf(const struct device *can_dev,
  * @param can_dev     The CAN device to be used for sending and receiving.
  * @param data        Data to be sent.
  * @param len         Length of the data to be sent.
- * @param rx_addr     Identifier for FC frames.
  * @param tx_addr     Identifier for outgoing frames the receiver listens on.
+ * @param rx_addr     Identifier for FC frames.
  * @param complete_cb Function called on completion or NULL.
  * @param cb_arg      Argument passed to the complete callback.
  * @param timeout     Timeout for buffer allocation.
@@ -393,8 +393,8 @@ int isotp_send_net_ctx_buf(const struct device *can_dev,
  * @param can_dev     The CAN device to be used for sending and receiving.
  * @param data        Data to be sent.
  * @param len         Length of the data to be sent.
- * @param rx_addr     Identifier for FC frames.
  * @param tx_addr     Identifier for outgoing frames the receiver listens on.
+ * @param rx_addr     Identifier for FC frames.
  * @param complete_cb Function called on completion or NULL.
  * @param cb_arg      Argument passed to the complete callback.
  * @param timeout     Timeout for buffer allocation.

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -192,8 +192,8 @@ static void send_sf(void)
 {
 	int ret;
 
-	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
-			 &rx_addr, &tx_addr, send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
+       ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
+                        &tx_addr, &rx_addr, send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -222,8 +222,8 @@ static void send_test_data(const uint8_t *data, size_t len)
 {
 	int ret;
 
-	ret = isotp_send(&send_ctx, can_dev, data, len, &rx_addr, &tx_addr,
-			 send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
+       ret = isotp_send(&send_ctx, can_dev, data, len, &tx_addr, &rx_addr,
+                        send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -457,9 +457,9 @@ ZTEST(isotp_conformance, test_send_sf_ext)
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
-	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF_EXT,
-			 &rx_addr_ext, &tx_addr_ext, send_complete_cb,
-			 INT_TO_POINTER(ISOTP_N_OK));
+       ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF_EXT,
+                        &tx_addr_ext, &rx_addr_ext, send_complete_cb,
+                        INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 
 	check_frame_series(&des_frame, 1, &frame_msgq);
@@ -514,9 +514,9 @@ ZTEST(isotp_conformance, test_send_sf_fixed)
 	zassert_true((filter_id >= 0), "Negative filter number [%d]",
 		     filter_id);
 
-	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
-			 &rx_addr_fixed, &tx_addr_fixed, send_complete_cb,
-			 INT_TO_POINTER(ISOTP_N_OK));
+       ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
+                        &tx_addr_fixed, &rx_addr_fixed, send_complete_cb,
+                        INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 
 	check_frame_series(&des_frame, 1, &frame_msgq);
@@ -1032,8 +1032,8 @@ ZTEST(isotp_conformance, test_canfd_mandatory_padding)
 
 	filter_id = add_rx_msgq(rx_addr.std_id, CAN_STD_ID_MASK);
 
-	ret = isotp_send(&send_ctx, can_dev, random_data, data_size_sf,
-			 &rx_addr, &tx_addr, send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
+       ret = isotp_send(&send_ctx, can_dev, random_data, data_size_sf,
+                        &tx_addr, &rx_addr, send_complete_cb, INT_TO_POINTER(ISOTP_N_OK));
 	zassert_equal(ret, 0, "Send returned %d", ret);
 
 	ret = k_msgq_get(&frame_msgq, &frame, K_MSEC(500));

--- a/tests/subsys/canbus/isotp/conformance/src/mode_check.c
+++ b/tests/subsys/canbus/isotp/conformance/src/mode_check.c
@@ -57,7 +57,7 @@ ZTEST(isotp_conformance_mode_check, test_send)
 	uint8_t buf[] = { 1, 2, 3 };
 	int err;
 
-	err = isotp_send(&send_ctx, can_dev, buf, sizeof(buf), &rx_addr, &tx_addr, NULL, NULL);
+       err = isotp_send(&send_ctx, can_dev, buf, sizeof(buf), &tx_addr, &rx_addr, NULL, NULL);
 	if (IS_ENABLED(CONFIG_TEST_USE_CAN_FD_MODE) && !canfd_capable) {
 		zassert_equal(err, ISOTP_N_ERROR);
 	} else {

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -56,8 +56,8 @@ static void send_sf(const struct device *can_dev)
 {
 	int ret;
 
-	ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
-			 &rx_addr, &tx_addr, send_complete_cb, NULL);
+       ret = isotp_send(&send_ctx, can_dev, random_data, DATA_SIZE_SF,
+                        &tx_addr, &rx_addr, send_complete_cb, NULL);
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 
@@ -106,8 +106,8 @@ static void send_test_data(const struct device *can_dev, const uint8_t *data,
 {
 	int ret;
 
-	ret = isotp_send(&send_ctx, can_dev, data, len, &rx_addr, &tx_addr,
-			  send_complete_cb, NULL);
+       ret = isotp_send(&send_ctx, can_dev, data, len, &tx_addr, &rx_addr,
+                         send_complete_cb, NULL);
 	zassert_equal(ret, 0, "Send returned %d", ret);
 }
 


### PR DESCRIPTION
## Summary
- fix parameter ordering in ISO-TP API documentation
- adjust tests to use proper argument order

## Testing
- `./scripts/twister -T tests/subsys/canbus/isotp/implementation -p native_posix --inline-logs -vv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684ddc049e6c832192ae0288dcf9d1cf