### PR TITLE
Fix modbus client and server issues

### DIFF
--- a/subsys/modbus/modbus_client.c
+++ b/subsys/modbus/modbus_client.c
@@ -226,12 +226,12 @@ static int mbc_validate_wr_response(struct modbus_context *ctx,
 	case MODBUS_FC06_HOLDING_REG_WR:
 	case MODBUS_FC15_COILS_WR:
 	case MODBUS_FC16_HOLDING_REGS_WR:
-		if (req_addr != resp_addr || req_value != resp_value) {
-			err = ENXIO;
-		} else {
-			err = 0;
-		}
-		break;
+               if (req_addr != resp_addr || req_value != resp_value) {
+                       err = -ENXIO;
+               } else {
+                       err = 0;
+               }
+               break;
 
 	default:
 		LOG_ERR("Validation not implemented for FC 0x%02x", fc);

--- a/subsys/modbus/modbus_server.c
+++ b/subsys/modbus/modbus_server.c
@@ -550,12 +550,15 @@ static bool mbs_fc05_coil_write(struct modbus_context *ctx)
 	coil_addr = sys_get_be16(&ctx->rx_adu.data[0]);
 	coil_val = sys_get_be16(&ctx->rx_adu.data[2]);
 
-	/* See if coil needs to be OFF? */
-	if (coil_val == MODBUS_COIL_OFF_CODE) {
-		coil_state = false;
-	} else {
-		coil_state = true;
-	}
+       /* Validate coil value */
+       if (coil_val == MODBUS_COIL_OFF_CODE) {
+               coil_state = false;
+       } else if (coil_val == MODBUS_COIL_ON_CODE) {
+               coil_state = true;
+       } else {
+               mbs_exception_rsp(ctx, MODBUS_EXC_ILLEGAL_DATA_VAL);
+               return true;
+       }
 
 	err = ctx->mbs_user_cb->coil_wr(coil_addr, coil_state);
 


### PR DESCRIPTION
## Summary
- correct ENXIO use when validating write responses
- validate coil values in the server before writing

## Testing
- `scripts/checkpatch.pl /tmp/diff.patch`

------
https://chatgpt.com/codex/tasks/task_e_684de7deb8d48321b267f48f5407d94e