### PR TITLE
Fix logging network socket release error message

### DIFF
--- a/subsys/logging/backends/log_backend_net.c
+++ b/subsys/logging/backends/log_backend_net.c
@@ -236,7 +236,7 @@ static bool check_net_init_done(void)
 
 		released = zsock_close(ctx->sock);
 		if (released < 0) {
-			LOG_ERR("Cannot release socket (%d)", ret);
+			LOG_ERR("Cannot release socket (%d)", released);
 			ret = false;
 		} else {
 			/* The socket is successfully closed so we flag it


### PR DESCRIPTION
## Summary
- fix log message when closing network socket in log backend

## Testing
- `./scripts/twister -T tests/subsys/logging/log_output_net -p native_sim --inline-logs -vv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684de7a5f8a883218da9d2f3e94fd238