### PR TITLE
Fix logging assert in dictionary frontend

### DIFF
--- a/subsys/logging/frontends/log_frontend_dict_uart.c
+++ b/subsys/logging/frontends/log_frontend_dict_uart.c
@@ -104,7 +104,7 @@ static void tx(void)
 
 	generic_pkt.ro_pkt = mpsc_pbuf_claim(&buf);
 	pkt = generic_pkt.generic;
-	__ASSERT_NO_MSG(pkt == NULL);
+       __ASSERT_NO_MSG(pkt != NULL);
 
 	size_t len = sizeof(uint32_t) * pkt->hdr.len - pkt->hdr.noff -
 			sizeof(struct log_frontend_uart_pkt_hdr);


### PR DESCRIPTION
## Summary
- fix incorrect assertion in log_frontend_dict_uart `tx()`

## Testing
- `./scripts/twister -T tests/subsys/logging/dictionary -p native_posix` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684de7a5f8a883218da9d2f3e94fd238