### PR TITLE
Fix rounding in util macro

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -368,7 +368,7 @@ extern "C" {
  * @return The result of @p n / @p d, rounded to the nearest integer.
  */
 #define DIV_ROUND_CLOSEST(n, d)                                                                    \
-	(((((__typeof__(n))-1) < 0) && (((__typeof__(d))-1) < 0) && ((n) < 0) ^ ((d) < 0))         \
+	(((((__typeof__(n))-1) < 0) && (((__typeof__(d))-1) < 0) && (((n) < 0) ^ ((d) < 0)))         \
 		 ? ((n) - ((d) / 2)) / (d)                                                         \
 		 : ((n) + ((d) / 2)) / (d))
 

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -673,6 +673,8 @@ ZTEST(util, test_DIV_ROUND_CLOSEST)
 	/* 7 / 3 = 2.(3) -> 2 */
 	zassert_equal(DIV_ROUND_CLOSEST(7, 3), 2);
 	zassert_equal(DIV_ROUND_CLOSEST(-7, 3), -2);
+        unsigned int u = 2U;
+        zassert_equal(DIV_ROUND_CLOSEST(-5, u), -3);
 }
 
 ZTEST(util, test_IF_DISABLED)


### PR DESCRIPTION
## Summary
- fix parenthesis error in `DIV_ROUND_CLOSEST`
- add test case covering signed/unsigned mix

## Testing
- `./scripts/twister -T tests/unit/util` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684de89edca48321ac60aed73ea36d58