### PR TITLE
Fix pointer overflow detection bug

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -741,9 +741,9 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
  *
  * @return true if pointer overflow detected, false otherwise
  */
-#define Z_DETECT_POINTER_OVERFLOW(addr, buflen)  \
-	(((buflen) != 0) &&                        \
-	((UINTPTR_MAX - (uintptr_t)(addr)) <= ((uintptr_t)((buflen) - 1))))
+#define Z_DETECT_POINTER_OVERFLOW(addr, buflen)   \
+       (((buflen) != 0) &&                        \
+        ((UINTPTR_MAX - (uintptr_t)(addr)) < ((uintptr_t)((buflen) - 1))))
 
 /**
  * @brief XOR n bytes

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -946,7 +946,7 @@ ZTEST(util, test_util_eq)
 
 ZTEST(util, test_util_memeq)
 {
-	uint8_t src1[16];
+        uint8_t src1[16];
 	uint8_t src2[16];
 	uint8_t src3[16];
 
@@ -965,8 +965,20 @@ ZTEST(util, test_util_memeq)
 	mem_area_matching_1 = util_memeq(src1, src2, sizeof(src1));
 	mem_area_matching_2 = util_memeq(src1, src3, sizeof(src1));
 
-	zassert_true(mem_area_matching_1);
-	zassert_false(mem_area_matching_2);
+        zassert_true(mem_area_matching_1);
+        zassert_false(mem_area_matching_2);
+}
+
+ZTEST(util, test_detect_pointer_overflow)
+{
+       zassert_false(Z_DETECT_POINTER_OVERFLOW((const void *)UINTPTR_MAX, 1),
+                     "single byte at max address should be valid");
+       zassert_true(Z_DETECT_POINTER_OVERFLOW((const void *)UINTPTR_MAX, 2),
+                    "two bytes at max address should overflow");
+       zassert_false(Z_DETECT_POINTER_OVERFLOW((const void *)(UINTPTR_MAX - 10), 11),
+                     "exact fit up to max address should be valid");
+       zassert_true(Z_DETECT_POINTER_OVERFLOW((const void *)(UINTPTR_MAX - 10), 12),
+                    "one byte past max address should overflow");
 }
 
 ZTEST_SUITE(util, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
## Summary
- fix logic in `Z_DETECT_POINTER_OVERFLOW`
- add regression tests for pointer overflow detection

## Testing
- `scripts/twister -T tests/unit/util` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684de89edca48321ac60aed73ea36d58