### PR TITLE
Fix trickle restart logic

### DIFF
--- a/include/zephyr/net/trickle.h
+++ b/include/zephyr/net/trickle.h
@@ -62,7 +62,7 @@ struct net_trickle {
 	uint8_t k;		/**< Redundancy constant */
 	uint8_t c;		/**< Consistency counter */
 
-	bool double_to;         /**< Flag telling if the internval is doubled */
+	bool double_to;         /**< Flag telling if the interval is doubled */
 
 	struct k_work_delayable timer; /**< Internal timer struct */
 	net_trickle_cb_t cb;	/**< Callback to be called when timer expires */

--- a/subsys/net/lib/trickle/trickle.c
+++ b/subsys/net/lib/trickle/trickle.c
@@ -136,9 +136,12 @@ static void trickle_timeout(struct k_work *work)
 
 static void setup_new_interval(struct net_trickle *trickle)
 {
-	uint32_t t;
+       uint32_t t;
 
-	trickle->c = 0U;
+       trickle->c = 0U;
+
+       /* Ensure that the next timeout triggers interval_timeout() */
+       trickle->double_to = false;
 
 	t = get_t(trickle->I);
 


### PR DESCRIPTION
## Summary
- ensure trickle restarts begin with interval timeout
- fix typo in `struct net_trickle` comment

## Testing
- `./scripts/twister -T tests/net/trickle -p native_sim -vv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e77b0fff08321b2f391bb1d8065bd