### PR TITLE
Fix Trickle interval start

### DIFF
--- a/subsys/net/lib/trickle/trickle.c
+++ b/subsys/net/lib/trickle/trickle.c
@@ -76,7 +76,7 @@ static void double_interval_timeout(struct net_trickle *trickle)
 
 	NET_DBG("doubling time %u", rand_time);
 
-	trickle->Istart = k_uptime_get_32() + rand_time;
+	trickle->Istart = k_uptime_get_32();
 	trickle->double_to = false;
 
 	k_work_reschedule(&trickle->timer, K_MSEC(rand_time));


### PR DESCRIPTION
## Summary
- fix Trickle interval handling by setting the interval start to the current time

## Testing
- `scripts/checkpatch.pl -q -f subsys/net/lib/trickle/trickle.c`
- `scripts/twister -T tests/net/trickle` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e77b0fff08321b2f391bb1d8065bd