### PR TITLE
Fix pointer overflow check

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -742,8 +742,8 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
  * @return true if pointer overflow detected, false otherwise
  */
 #define Z_DETECT_POINTER_OVERFLOW(addr, buflen)  \
-	(((buflen) != 0) &&                        \
-	((UINTPTR_MAX - (uintptr_t)(addr)) <= ((uintptr_t)((buflen) - 1))))
+       (((buflen) != 0) &&                        \
+       ((UINTPTR_MAX - (uintptr_t)(addr)) < ((uintptr_t)((buflen) - 1))))
 
 /**
  * @brief XOR n bytes

--- a/tests/unit/util/main.c
+++ b/tests/unit/util/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/sys/util.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 
 ZTEST(util, test_u8_to_dec) {
 	char text[4];
@@ -965,8 +966,20 @@ ZTEST(util, test_util_memeq)
 	mem_area_matching_1 = util_memeq(src1, src2, sizeof(src1));
 	mem_area_matching_2 = util_memeq(src1, src3, sizeof(src1));
 
-	zassert_true(mem_area_matching_1);
-	zassert_false(mem_area_matching_2);
+       zassert_true(mem_area_matching_1);
+       zassert_false(mem_area_matching_2);
+}
+
+ZTEST(util, test_Z_DETECT_POINTER_OVERFLOW)
+{
+       uintptr_t max_addr = UINTPTR_MAX;
+
+       zassert_false(Z_DETECT_POINTER_OVERFLOW((void *)max_addr, 1),
+                     "overflow reported for single byte at max address");
+       zassert_true(Z_DETECT_POINTER_OVERFLOW((void *)max_addr, 2),
+                    "overflow not detected for two bytes at max address");
+       zassert_false(Z_DETECT_POINTER_OVERFLOW((void *)0, 1),
+                     "overflow reported for address 0 len 1");
 }
 
 ZTEST_SUITE(util, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
## Summary
- fix off-by-one check in `Z_DETECT_POINTER_OVERFLOW`
- add unit test for pointer overflow detection

## Testing
- `scripts/twister -T tests/unit/util --inline-logs -vvv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e149cdfcc8321a09866d79e58b3bb