### PR TITLE
Fix mDNS header check

### DIFF
--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -205,7 +205,6 @@ int dns_unpack_response_header(struct dns_msg_t *msg, int src_id)
 	if (dns_header_opcode(dns_header) != DNS_QUERY) {
 		return -EINVAL;
 	}
-
 	if (dns_header_z(dns_header) != 0) {
 		return -EINVAL;
 	}
@@ -462,7 +461,7 @@ int mdns_unpack_query_header(struct dns_msg_t *msg, uint16_t *src_id)
 		return -EINVAL;
 	}
 
-	if (dns_header_opcode(dns_header) != 0) {
+	if (dns_header_z(dns_header) != 0) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
## Summary
- fix wrong field validation in `mdns_unpack_query_header`

## Testing
- `scripts/checkpatch.pl -f subsys/net/lib/dns/dns_pack.c`

------
https://chatgpt.com/codex/tasks/task_e_684e779d39a4832189e8ed2c00659cac