### PR TITLE
Fix provider callback logic in DHCPv4 server

### DIFF
--- a/subsys/net/lib/dhcpv4/dhcpv4_server.c
+++ b/subsys/net/lib/dhcpv4/dhcpv4_server.c
@@ -986,16 +986,16 @@ static void dhcpv4_handle_discover(struct dhcpv4_server_ctx *ctx,
 			break;
 		}
 		struct in_addr addr = { 0 };
-
+		
 		if (slot->state == DHCPV4_SERVER_ADDR_FREE &&
 		    address_provider_callback) {
-			ret = address_provider_callback(ctx->iface, &client_id, &addr,
-							address_provider_callback_user_data);
-			if (ret == 0) {
-				selected = slot;
-				slot->addr = addr;
-			}
-			break;
+		ret = address_provider_callback(ctx->iface, &client_id, &addr,
+		address_provider_callback_user_data);
+		if (ret == 0) {
+		selected = slot;
+		slot->addr = addr;
+		break;
+		}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- ensure DHCPv4 server continues scanning address pool when provider callback rejects an address

## Testing
- `./scripts/twister -T tests/net/dhcpv4 --inline-logs -v` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e76b35a148321879e5161f4405173