### PR TITLE
Fix double free in CANBUS L2

### DIFF
--- a/subsys/net/l2/canbus/canbus_raw.c
+++ b/subsys/net/l2/canbus/canbus_raw.c
@@ -32,17 +32,16 @@ static inline int canbus_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	const struct canbus_api *api = net_if_get_device(iface)->api;
 	int ret;
-
+	
 	if (!api) {
 		return -ENOENT;
 	}
-
+	
 	ret = net_l2_send(api->send, net_if_get_device(iface), iface, pkt);
 	if (!ret) {
 		ret = net_pkt_get_len(pkt);
-		net_pkt_unref(pkt);
 	}
-
+	
 	return ret;
 }
 


### PR DESCRIPTION
## Summary
- avoid freeing CAN packets twice
- clean up indentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'conftest')*

------
https://chatgpt.com/codex/tasks/task_e_684e84061668832191bcbcd53e33c69c