### PR TITLE
Fix sequence tracker calculation

### DIFF
--- a/subsys/net/ip/tp.c
+++ b/subsys/net/ip/tp.c
@@ -303,7 +303,8 @@ uint32_t tp_seq_track(int kind, uint32_t *pvalue, int req,
 		seq->of = __builtin_uadd_overflow(seq->old_value, seq->req,
 							&seq->value);
 	} else {
-		seq->value += req;
+		/* seq->value was zeroed by k_calloc(), so add from old value */
+		seq->value = seq->old_value + req;
 	}
 
 	*pvalue = seq->value;


### PR DESCRIPTION
## Summary
- fix initialization for negative increments in sequence tracker

## Testing
- `perl scripts/checkpatch.pl --no-tree`

------
https://chatgpt.com/codex/tasks/task_e_684e833343e48321b1a2e9324a7c4b2e