### PR TITLE
Optimize board processing

### DIFF
--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -63,7 +63,8 @@ zephyr_check_cache(BOARD REQUIRED)
 # 'BOARD_ROOT' is a prioritized list of directories where boards may
 # be found. It always includes ${ZEPHYR_BASE} at the lowest priority (except for unittesting).
 if(NOT unittest IN_LIST Zephyr_FIND_COMPONENTS)
-  list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
+	list(APPEND BOARD_ROOT ${ZEPHYR_BASE})
+	list(REMOVE_DUPLICATES BOARD_ROOT)
 endif()
 
 # Helper function for parsing a board's name, revision, and qualifiers,

--- a/scripts/list_boards.py
+++ b/scripts/list_boards.py
@@ -388,23 +388,25 @@ def variant_v2_qualifiers(variant, qualifiers = None):
 
 
 def board_v2_qualifiers(board):
-    qualifiers_list = []
-
-    for s in board.socs:
-        if s.cpuclusters:
-            for c in s.cpuclusters:
-                id_str = s.name + '/' + c.name
-                qualifiers_list.append(id_str)
-                for v in c.variants:
-                    qualifiers_list.extend(variant_v2_qualifiers(v, id_str))
-        else:
-            qualifiers_list.append(s.name)
-            for v in s.variants:
-                qualifiers_list.extend(variant_v2_qualifiers(v, s.name))
-
-    for v in board.variants:
-        qualifiers_list.extend(variant_v2_qualifiers(v))
-    return qualifiers_list
+	cached = getattr(board, '_qualifiers_cache', None)
+	if cached is not None:
+		return cached
+	qualifiers_list = []
+	for s in board.socs:
+		if s.cpuclusters:
+			for c in s.cpuclusters:
+				id_str = s.name + '/' + c.name
+				qualifiers_list.append(id_str)
+				for v in c.variants:
+					qualifiers_list.extend(variant_v2_qualifiers(v, id_str))
+		else:
+			qualifiers_list.append(s.name)
+			for v in s.variants:
+				qualifiers_list.extend(variant_v2_qualifiers(v, s.name))
+	for v in board.variants:
+		qualifiers_list.extend(variant_v2_qualifiers(v))
+	object.__setattr__(board, '_qualifiers_cache', qualifiers_list)
+	return qualifiers_list
 
 
 def board_v2_qualifiers_csv(board):


### PR DESCRIPTION
## Summary
- deduplicate BOARD_ROOT list
- cache board qualifier computation for faster board listing

## Testing
- `python3 -m py_compile scripts/list_boards.py`
- `pytest -k nothing -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684e8a4b32508321b1bd6a9b5efa282b