### PR TITLE
Handle unknown critical CoAP options

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -65,8 +65,39 @@ static struct coap_transmission_parameters coap_transmission_params = {
 	.coap_backoff_percent = CONFIG_COAP_BACKOFF_PERCENT
 };
 
-static int insert_option(struct coap_packet *cpkt, uint16_t code, const uint8_t *value,
-			 uint16_t len);
+static int insert_option(struct coap_packet *cpkt, uint16_t code,
+                        const uint8_t *value, uint16_t len);
+
+static bool option_is_known(uint16_t code)
+{
+	switch (code) {
+	case COAP_OPTION_IF_MATCH:
+	case COAP_OPTION_URI_HOST:
+	case COAP_OPTION_ETAG:
+	case COAP_OPTION_IF_NONE_MATCH:
+	case COAP_OPTION_OBSERVE:
+	case COAP_OPTION_URI_PORT:
+	case COAP_OPTION_LOCATION_PATH:
+	case COAP_OPTION_URI_PATH:
+	case COAP_OPTION_CONTENT_FORMAT:
+	case COAP_OPTION_MAX_AGE:
+	case COAP_OPTION_URI_QUERY:
+	case COAP_OPTION_ACCEPT:
+	case COAP_OPTION_LOCATION_QUERY:
+	case COAP_OPTION_BLOCK2:
+	case COAP_OPTION_BLOCK1:
+	case COAP_OPTION_SIZE2:
+	case COAP_OPTION_PROXY_URI:
+	case COAP_OPTION_PROXY_SCHEME:
+	case COAP_OPTION_SIZE1:
+	case COAP_OPTION_ECHO:
+	case COAP_OPTION_NO_RESPONSE:
+	case COAP_OPTION_REQUEST_TAG:
+	return true;
+	default:
+	return false;
+	}
+}
 
 static inline void encode_u8(struct coap_packet *cpkt, uint16_t offset, uint8_t data)
 {
@@ -796,12 +827,17 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		struct coap_option *option;
 
 		option = num < opt_num ? &options[num++] : NULL;
-		ret = parse_option(cpkt->data, offset, &offset, cpkt->max_len,
-				   &delta, &opt_len, option);
+		ret = parse_option(cpkt->data, offset, &offset,
+				cpkt->max_len, &delta, &opt_len,
+				option);
 		if (ret < 0) {
 			return -EILSEQ;
 		} else if (ret == 0) {
 			break;
+		}
+
+		if (!option_is_known(delta) && (delta & 1U)) {
+			return -EBADMSG;
 		}
 	}
 
@@ -809,6 +845,7 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 	cpkt->delta = delta;
 
 	return 0;
+
 }
 
 int coap_packet_set_path(struct coap_packet *cpkt, const char *path)

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -386,6 +386,24 @@ ZTEST(coap, test_parse_malformed_marker)
 	r = coap_packet_parse(&cpkt, data, sizeof(pdu), NULL, 0);
 	zassert_not_equal(r, 0, "Should've failed to parse a packet");
 }
+ZTEST(coap, test_parse_unknown_critical_option)
+{
+	struct coap_packet pkt;
+	struct coap_packet parsed;
+	uint8_t *data = data_buf[0];
+	int r;
+
+	r = coap_packet_init(&pkt, data, COAP_BUF_SIZE, COAP_VERSION_1,
+			COAP_TYPE_CON, 0, NULL, COAP_METHOD_GET, 0x1234);
+	zassert_equal(r, 0, "Could not init packet");
+
+	r = coap_packet_append_option(&pkt, 13, NULL, 0);
+	zassert_equal(r, 0, "Could not append option");
+
+	r = coap_packet_parse(&parsed, data, pkt.offset, NULL, 0);
+	zassert_equal(r, -EBADMSG, "Parser should reject unknown critical option");
+}
+
 
 ZTEST(coap, test_parse_req_build_ack)
 {


### PR DESCRIPTION
## Summary
- validate CoAP option numbers against known list
- reject packets with unknown critical options
- add test for unknown critical option handling

## Testing
- `./scripts/twister -s tests/net/lib/coap --inline-logs -vv` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e8f39a0608321a80b851543fe1cae