### PR TITLE
Fix buffer overread in CoAP resource discovery

### DIFF
--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -81,6 +81,9 @@ static bool match_path_uri(const char * const *path,
 			k = i;
 
 			for (j = 0; j < plen; j++) {
+			if (k >= len) {
+					goto next;
+				}
 				if (uri[k] == '*') {
 					if ((k + 1) == len) {
 						return true;

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -482,6 +482,11 @@ ZTEST(coap, test_match_path_uri)
 	uri = "/devnull*";
 	r = _coap_match_path_uri(resource_path, uri, strlen(uri));
 	zassert_false(r, "Matching %s failed", uri);
+	/* truncated URI should not match */
+
+	uri = "/fo";
+	r = _coap_match_path_uri(resource_path, uri, strlen(uri));
+	zassert_false(r, "Matching %s failed", uri);
 }
 
 #define BLOCK_WISE_TRANSFER_SIZE_GET 150


### PR DESCRIPTION
## Summary
- audit `.well-known/core` implementation
- fix potential buffer overread when matching URI filters
- add unit test for truncated URI path matching
- document the new test

## Testing
- `perl scripts/checkpatch.pl --no-tree -g HEAD`
- `./scripts/twister -T tests/net/lib/coap -b native_posix` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e8f48ff4c8321b0b9d87d5ad730bd