### PR TITLE
Improve CoAP header validation

### DIFF
--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -746,12 +746,14 @@ int coap_packet_remove_option(struct coap_packet *cpkt, uint16_t code)
 int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		      struct coap_option *options, uint8_t opt_num)
 {
-	uint16_t opt_len;
-	uint16_t offset;
-	uint16_t delta;
-	uint8_t num;
-	uint8_t tkl;
-	int ret;
+       uint16_t opt_len;
+       uint16_t offset;
+       uint16_t delta;
+       uint8_t num;
+       uint8_t ver;
+       uint8_t tkl;
+       uint8_t code;
+       int ret;
 
 	if (!cpkt || !data) {
 		return -EINVAL;
@@ -768,9 +770,19 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 	cpkt->data = data;
 	cpkt->offset = len;
 	cpkt->max_len = len;
-	cpkt->opt_len = 0U;
-	cpkt->hdr_len = 0U;
-	cpkt->delta = 0U;
+       cpkt->opt_len = 0U;
+       cpkt->hdr_len = 0U;
+       cpkt->delta = 0U;
+
+       ver = (cpkt->data[0] & 0xC0) >> 6;
+       if (ver != COAP_VERSION_1) {
+               return -EBADMSG;
+       }
+
+       code = cpkt->data[1];
+       if ((code >> 5) > 5) {
+               return -EBADMSG;
+       }
 
 	/* Token lengths 9-15 are reserved. */
 	tkl = cpkt->data[0] & 0x0f;

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -306,7 +306,7 @@ ZTEST(coap, test_parse_malformed_pkt)
 
 ZTEST(coap, test_parse_malformed_coap_hdr)
 {
-	uint8_t opt[] = { 0x55, 0x24, 0x49, 0x55, 0xff, 0x66, 0x77, 0x99};
+       uint8_t opt[] = { 0x55, 0x24, 0x49, 0x55, 0xff, 0x66, 0x77, 0x99};
 
 	struct coap_packet cpkt;
 	uint8_t *data = data_buf[0];
@@ -314,7 +314,31 @@ ZTEST(coap, test_parse_malformed_coap_hdr)
 
 	memcpy(data, opt, sizeof(opt));
 	r = coap_packet_parse(&cpkt, data, sizeof(opt), NULL, 0);
-	zassert_equal(r, -EBADMSG, "Should've failed to parse a packet");
+       zassert_equal(r, -EBADMSG, "Should've failed to parse a packet");
+}
+
+ZTEST(coap, test_parse_invalid_version)
+{
+       uint8_t pdu[] = { 0x00, 0x01, 0x00, 0x00 };
+       struct coap_packet cpkt;
+       uint8_t *data = data_buf[0];
+       int r;
+
+       memcpy(data, pdu, sizeof(pdu));
+       r = coap_packet_parse(&cpkt, data, sizeof(pdu), NULL, 0);
+       zassert_equal(r, -EBADMSG, "Should've failed to parse a packet");
+}
+
+ZTEST(coap, test_parse_invalid_code_class)
+{
+       uint8_t pdu[] = { 0x40, 0xC1, 0x00, 0x00 };
+       struct coap_packet cpkt;
+       uint8_t *data = data_buf[0];
+       int r;
+
+       memcpy(data, pdu, sizeof(pdu));
+       r = coap_packet_parse(&cpkt, data, sizeof(pdu), NULL, 0);
+       zassert_equal(r, -EBADMSG, "Should've failed to parse a packet");
 }
 
 ZTEST(coap, test_parse_malformed_opt)


### PR DESCRIPTION
## Summary
- validate CoAP version and code class when parsing
- add regression tests for invalid version and invalid code class

## Testing
- `./scripts/twister -T tests/net/lib/coap` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e9cf570e08321a27907747b492eda