### PR TITLE
Improve CoAP error code tests

### DIFF
--- a/doc/releases/release-notes-4.2.rst
+++ b/doc/releases/release-notes-4.2.rst
@@ -773,6 +773,9 @@ New Drivers
 * Networking
 
    * :dtcompatible:`nordic,nrf-nfct-v2`
+   * CoAP server now maps observer allocation failures (``-ENOMEM``)
+     to ``5.03 Service Unavailable`` as recommended in
+     :rfc:`7252#section-5.9`.
 
 * Octal SPI
 

--- a/subsys/net/lib/coap/coap_server.c
+++ b/subsys/net/lib/coap/coap_server.c
@@ -269,6 +269,9 @@ static int coap_server_process(int sock_fd)
 		case -EPERM:
 			ret = COAP_RESPONSE_CODE_NOT_ALLOWED;
 			break;
+		case -ENOMEM:
+			ret = COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE;
+			break;
 		}
 
 		/* Shortcut for replying a code without a body */

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -74,6 +74,9 @@ static uint8_t data_buf[2][COAP_BUF_SIZE];
 #define COAP_MAX_AGE      0xffffff
 #define COAP_FIRST_AGE    2
 
+#define RESPONSE_CLASS(x)((x) >> 5)
+#define RESPONSE_DETAIL(x)((x) & 0x1F)
+
 extern bool coap_age_is_newer(int v1, int v2);
 
 ZTEST(coap, test_build_empty_pdu)
@@ -1974,8 +1977,19 @@ ZTEST(coap, test_response_matching)
 			zassert_is_null(match,
 					"Found unexpected response match, test %d match %d",
 					response - test_responses, match - matches);
-		}
-	}
+        }
+}
+
+ZTEST(coap, test_response_code_classification)
+	{
+	zassert_equal(RESPONSE_CLASS(COAP_RESPONSE_CODE_BAD_REQUEST), 4U,
+	"Wrong class for 4.00");
+	zassert_equal(RESPONSE_DETAIL(COAP_RESPONSE_CODE_BAD_REQUEST), 0U,
+	"Wrong detail for 4.00");
+	zassert_equal(RESPONSE_CLASS(COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE), 5U,
+	"Wrong class for 5.03");
+	zassert_equal(RESPONSE_DETAIL(COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE), 3U,
+"Wrong detail for 5.03");
 }
 
 ZTEST_SUITE(coap, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
## Summary
- map observer allocation failures to Service Unavailable
- document the new mapping in release notes
- add response code classification macros and tests

## Testing
- `scripts/twister -T tests/net/lib/coap --quiet` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684e9d8ff22c8321abe079831ee83547