### PR TITLE
Optimize i2c burst copy

### DIFF
--- a/drivers/i2c/i2c_andes_atciic100.c
+++ b/drivers/i2c/i2c_andes_atciic100.c
@@ -164,14 +164,9 @@ static int i2c_atciic100_transfer(const struct device *dev,
 		if (burst_write_len > MAX_XFER_SZ) {
 			return -EIO;
 		}
-		for (count = 0; count < burst_write_len; count++) {
-			if (count < msgs[0].len) {
-				burst_write_buf[count] = msgs[0].buf[count];
-			} else {
-				burst_write_buf[count] =
-					msgs[1].buf[count - msgs[0].len];
-			}
-		}
+		memcpy(burst_write_buf, msgs[0].buf, msgs[0].len);
+		memcpy(burst_write_buf + msgs[0].len, msgs[1].buf,
+			msgs[1].len);
 		ret = i2c_atciic100_controller_send(dev, addr, burst_write_buf,
 							burst_write_len, true);
 		goto exit;


### PR DESCRIPTION
## Summary
- improve burst write handling in Andes ATCIIC100 driver

## Testing
- `scripts/twister -T tests/drivers/i2c -p native_sim` *(fails: CMake build failure)*

------
https://chatgpt.com/codex/tasks/task_e_684f3eb4548c8321ba4aec2ccbd6e885