### PR TITLE
Make static configuration data const

### DIFF
--- a/drivers/adc/adc_mchp_xec.c
+++ b/drivers/adc/adc_mchp_xec.c
@@ -453,7 +453,7 @@ static int adc_xec_init(const struct device *dev)
 
 PINCTRL_DT_INST_DEFINE(0);
 
-static struct adc_xec_config adc_xec_dev_cfg_0 = {
+static const struct adc_xec_config adc_xec_dev_cfg_0 = {
 	.regs = (struct adc_xec_regs *)(DT_INST_REG_ADDR(0)),
 	.girq_single = (uint8_t)(DT_INST_PROP_BY_IDX(0, girqs, 0)),
 	.girq_single_pos = (uint8_t)(DT_INST_PROP_BY_IDX(0, girqs, 1)),

--- a/drivers/adc/adc_realtek_rts5912.c
+++ b/drivers/adc/adc_realtek_rts5912.c
@@ -286,7 +286,7 @@ static int adc_rts5912_init(const struct device *dev)
 		.ref_internal = DT_INST_PROP(n, vref_mv),                                          \
 	};                                                                                         \
                                                                                                    \
-	static struct adc_rts5912_config adc_rts5912_dev_cfg_##n = {                               \
+	static const struct adc_rts5912_config adc_rts5912_dev_cfg_##n = {                               \
 		.regs = (struct adc_regs *)(DT_INST_REG_ADDR(n)),                                  \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 		DEV_CONFIG_CLK_DEV_INIT(n)};                                                       \

--- a/drivers/display/display_renesas_ra.c
+++ b/drivers/display/display_renesas_ra.c
@@ -497,7 +497,7 @@ static int display_init(const struct device *dev)
 			.line_detect_ipl = DT_INST_IRQ_BY_NAME(id, line, priority),                \
 			.underflow_1_irq = BSP_IRQ_DISABLED,                                       \
 			.underflow_2_irq = BSP_IRQ_DISABLED}};                                     \
-	static struct display_ra_config ra_config##id = {                                          \
+	static const struct display_ra_config ra_config##id = {                                          \
 		IRQ_CONFIGURE_DEFINE(id),                                                          \
 		.pincfg = RENESAS_RA_GLCDC_DEVICE_PINCTRL_GET(id),                                 \
 		.backlight_gpio = GPIO_DT_SPEC_INST_GET_OR(id, backlight_gpios, NULL),             \

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -71,8 +71,8 @@ struct ssd16xx_data {
 };
 
 struct ssd16xx_dt_array {
-	uint8_t *data;
-	uint8_t len;
+       const uint8_t *data;
+       uint8_t len;
 };
 
 struct ssd16xx_profile {
@@ -957,7 +957,7 @@ static DEVICE_API(display, ssd16xx_driver_api) = {
 };
 
 #if DT_HAS_COMPAT_STATUS_OKAY(solomon_ssd1608)
-static struct ssd16xx_quirks quirks_solomon_ssd1608 = {
+static const struct ssd16xx_quirks quirks_solomon_ssd1608 = {
 	.max_width = 320,
 	.max_height = 240,
 	.pp_width_bits = 16,
@@ -968,7 +968,7 @@ static struct ssd16xx_quirks quirks_solomon_ssd1608 = {
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(solomon_ssd1673)
-static struct ssd16xx_quirks quirks_solomon_ssd1673 = {
+static const struct ssd16xx_quirks quirks_solomon_ssd1673 = {
 	.max_width = 250,
 	.max_height = 150,
 	.pp_width_bits = 8,
@@ -979,7 +979,7 @@ static struct ssd16xx_quirks quirks_solomon_ssd1673 = {
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(solomon_ssd1675a)
-static struct ssd16xx_quirks quirks_solomon_ssd1675a = {
+static const struct ssd16xx_quirks quirks_solomon_ssd1675a = {
 	.max_width = 296,
 	.max_height = 160,
 	.pp_width_bits = 8,
@@ -1001,7 +1001,7 @@ static const struct ssd16xx_quirks quirks_solomon_ssd1680 = {
 #endif
 
 #if DT_HAS_COMPAT_STATUS_OKAY(solomon_ssd1681)
-static struct ssd16xx_quirks quirks_solomon_ssd1681 = {
+static const struct ssd16xx_quirks quirks_solomon_ssd1681 = {
 	.max_width = 200,
 	.max_height = 200,
 	.pp_width_bits = 8,
@@ -1017,8 +1017,8 @@ static struct ssd16xx_quirks quirks_solomon_ssd1681 = {
 			.len = sizeof(softstart_##n),			\
 		},
 
-#define SSD16XX_MAKE_ARRAY_OPT(n, p)					\
-	static uint8_t data_ ## n ## _ ## p[] = DT_PROP_OR(n, p, {})
+#define SSD16XX_MAKE_ARRAY_OPT(n, p)
+	static const uint8_t data_ ## n ## _ ## p[] = DT_PROP_OR(n, p, {})
 
 #define SSD16XX_ASSIGN_ARRAY(n, p)					\
 	{								\

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -29,8 +29,8 @@ LOG_MODULE_REGISTER(uc81xx, CONFIG_DISPLAY_LOG_LEVEL);
 #define UC81XX_PIXELS_PER_BYTE		8U
 
 struct uc81xx_dt_array {
-	uint8_t *data;
-	uint8_t len;
+       const uint8_t *data;
+       uint8_t len;
 };
 
 enum uc81xx_profile_type {
@@ -718,11 +718,11 @@ static DEVICE_API(display, uc81xx_driver_api) = {
 	.set_pixel_format = uc81xx_set_pixel_format,
 };
 
-#define UC81XX_MAKE_ARRAY_OPT(n, p)					\
-	static uint8_t data_ ## n ## _ ## p[] = DT_PROP_OR(n, p, {})
+#define UC81XX_MAKE_ARRAY_OPT(n, p)
+	static const uint8_t data_ ## n ## _ ## p[] = DT_PROP_OR(n, p, {})
 
-#define UC81XX_MAKE_ARRAY(n, p)						\
-	static uint8_t data_ ## n ## _ ## p[] = DT_PROP(n, p)
+#define UC81XX_MAKE_ARRAY(n, p)
+	static const uint8_t data_ ## n ## _ ## p[] = DT_PROP(n, p)
 
 #define UC81XX_ASSIGN_ARRAY(n, p)					\
 	{								\

--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -51,7 +51,7 @@ static uint32_t used_pmc_banks_reported;
  * unmap the unused L2 memory and power off corresponding memory banks.
  */
 __attribute__((__section__(".unused_ram_start_marker")))
-static int unused_l2_sram_start_marker = 0xba0babce;
+static const int unused_l2_sram_start_marker = 0xba0babce;
 #define UNUSED_L2_START_ALIGNED ROUND_UP(POINTER_TO_UINT(&unused_l2_sram_start_marker), \
 					 CONFIG_MM_DRV_PAGE_SIZE)
 

--- a/drivers/smbus/smbus_stm32.c
+++ b/drivers/smbus/smbus_stm32.c
@@ -276,7 +276,7 @@ static DEVICE_API(smbus, smbus_stm32_api) = {
 
 #define SMBUS_STM32_DEVICE_INIT(n)                                                                 \
 	PINCTRL_DT_INST_DEFINE(n);                                                                 \
-	static struct smbus_stm32_config smbus_stm32_config_##n = {                                \
+	static const struct smbus_stm32_config smbus_stm32_config_##n = {                                \
 		.i2c_dev = DEVICE_DT_GET(DT_INST_PROP(n, i2c)),                                    \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),                                         \
 	};                                                                                         \

--- a/subsys/input/input_hid.c
+++ b/subsys/input/input_hid.c
@@ -9,7 +9,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/usb/class/hid.h>
 
-static uint8_t input_to_hid_map[] = {
+static const uint8_t input_to_hid_map[] = {
 	[INPUT_KEY_A] = HID_KEY_A,
 	[INPUT_KEY_B] = HID_KEY_B,
 	[INPUT_KEY_C] = HID_KEY_C,


### PR DESCRIPTION
## Summary
- mark HID key map as const
- store SSD16xx driver data arrays in flash
- store UC81xx driver data arrays in flash
- mark various driver config structs as const
- mark unused L2 SRAM marker const

## Testing
- `pip install west`
- `west build -b native_posix samples/hello_world` *(fails: `west` not in workspace)*
- `./scripts/twister --version` *(fails: missing Python packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f8a29d92c83218e8f9740a4cca9dd