### PR TITLE
Fix lvgl typos and fs flags

### DIFF
--- a/modules/lvgl/lvgl_fs.c
+++ b/modules/lvgl/lvgl_fs.c
@@ -13,6 +13,7 @@
 
 static bool lvgl_fs_ready(lv_fs_drv_t *drv)
 {
+	ARG_UNUSED(drv);
 	return true;
 }
 
@@ -26,10 +27,10 @@ static lv_fs_res_t errno_to_lv_fs_res(int err)
 		return LV_FS_RES_HW_ERR;
 	case -EBADF:
 		/*Error in the file system structure */
-		return LV_FS_RES_FS_ERR;
+	return LV_FS_RES_FS_ERR;
 	case -ENOENT:
-		/*Driver, file or directory is not exists*/
-		return LV_FS_RES_NOT_EX;
+	/*Driver, file or directory does not exist*/
+	return LV_FS_RES_NOT_EX;
 	case -EFBIG:
 		/*Disk full*/
 		return LV_FS_RES_FULL;
@@ -56,16 +57,20 @@ static lv_fs_res_t errno_to_lv_fs_res(int err)
 static void *lvgl_fs_open(lv_fs_drv_t *drv, const char *path, lv_fs_mode_t mode)
 {
 	int err;
-	int zmode = FS_O_CREATE;
+	int zmode = 0;
 	void *file;
 
 	/* LVGL is passing absolute paths without the root slash add it back
-	 * by decrementing the path pointer.
-	 */
+	* by decrementing the path pointer.
+	*/
 	path--;
 
-	zmode |= (mode & LV_FS_MODE_WR) ? FS_O_WRITE : 0;
-	zmode |= (mode & LV_FS_MODE_RD) ? FS_O_READ : 0;
+	if (mode & LV_FS_MODE_WR) {
+	zmode |= FS_O_WRITE | FS_O_CREATE;
+	}
+	if (mode & LV_FS_MODE_RD) {
+	zmode |= FS_O_READ;
+	}
 
 	file = lv_malloc(sizeof(struct fs_file_t));
 	if (!file) {

--- a/modules/lvgl/lvgl_zephyr_osal.c
+++ b/modules/lvgl/lvgl_zephyr_osal.c
@@ -44,10 +44,10 @@ lv_result_t lv_thread_delete(lv_thread_t *thread)
 
 	k_thread_abort(thread->tid);
 	ret = k_thread_stack_free(thread->stack);
-	if (ret < 0) {
-		LOG_ERR("Failled to delete thread: %d", ret);
-		return LV_RESULT_INVALID;
-	}
+       if (ret < 0) {
+	       LOG_ERR("Failed to delete thread: %d", ret);
+	       return LV_RESULT_INVALID;
+       }
 
 	return LV_RESULT_OK;
 }


### PR DESCRIPTION
## Summary
- fix typos in lvgl_zephyr_osal and lvgl_fs
- avoid creating files when opening for read in lvgl_fs
- silence unused parameter warning in lvgl_fs

## Testing
- `west build -p auto -b qemu_x86 samples/hello_world` *(failed: no west workspace)*
- `./scripts/checkpatch.pl --no-tree -f modules/lvgl/lvgl_fs.c modules/lvgl/lvgl_zephyr_osal.c`

------
https://chatgpt.com/codex/tasks/task_e_6852ac61086083219227ca128dcad0c5