### PR TITLE
Fix LVGL pointer inversion and typo

### DIFF
--- a/modules/lvgl/input/lvgl_pointer_input.c
+++ b/modules/lvgl/input/lvgl_pointer_input.c
@@ -71,18 +71,18 @@ static void lvgl_pointer_process_event(struct input_event *evt, void *user_data)
 	if (cfg->invert_x) {
 		if (cap->current_orientation == DISPLAY_ORIENTATION_NORMAL ||
 		    cap->current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tmp_point.x = cap->x_resolution - tmp_point.x;
+			tmp_point.x = cap->x_resolution - 1 - tmp_point.x;
 		} else {
-			tmp_point.x = cap->y_resolution - tmp_point.x;
+			tmp_point.x = cap->y_resolution - 1 - tmp_point.x;
 		}
 	}
 
 	if (cfg->invert_y) {
 		if (cap->current_orientation == DISPLAY_ORIENTATION_NORMAL ||
 		    cap->current_orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tmp_point.y = cap->y_resolution - tmp_point.y;
+			tmp_point.y = cap->y_resolution - 1 - tmp_point.y;
 		} else {
-			tmp_point.y = cap->x_resolution - tmp_point.y;
+			tmp_point.y = cap->x_resolution - 1 - tmp_point.y;
 		}
 	}
 
@@ -94,14 +94,14 @@ static void lvgl_pointer_process_event(struct input_event *evt, void *user_data)
 		break;
 	case DISPLAY_ORIENTATION_ROTATED_90:
 		point->x = tmp_point.y;
-		point->y = cap->y_resolution - tmp_point.x;
+		point->y = cap->y_resolution - 1 - tmp_point.x;
 		break;
 	case DISPLAY_ORIENTATION_ROTATED_180:
-		point->x = cap->x_resolution - tmp_point.x;
-		point->y = cap->y_resolution - tmp_point.y;
+		point->x = cap->x_resolution - 1 - tmp_point.x;
+		point->y = cap->y_resolution - 1 - tmp_point.y;
 		break;
 	case DISPLAY_ORIENTATION_ROTATED_270:
-		point->x = cap->x_resolution - tmp_point.y;
+		point->x = cap->x_resolution - 1 - tmp_point.y;
 		point->y = tmp_point.x;
 		break;
 	default:

--- a/modules/lvgl/lvgl_zephyr_osal.c
+++ b/modules/lvgl/lvgl_zephyr_osal.c
@@ -45,7 +45,7 @@ lv_result_t lv_thread_delete(lv_thread_t *thread)
 	k_thread_abort(thread->tid);
 	ret = k_thread_stack_free(thread->stack);
 	if (ret < 0) {
-		LOG_ERR("Failled to delete thread: %d", ret);
+		LOG_ERR("Failed to delete thread: %d", ret);
 		return LV_RESULT_INVALID;
 	}
 


### PR DESCRIPTION
## Summary
- correct coordinate inversion math in LVGL pointer input handling
- fix typo in LVGL OSAL log message

## Testing
- `./scripts/checkpatch.pl --no-tree -f modules/lvgl/input/lvgl_pointer_input.c modules/lvgl/lvgl_zephyr_osal.c`
- `west update` *(failed: environment limitations prevent full build setup)*

------
https://chatgpt.com/codex/tasks/task_e_6852ac61086083219227ca128dcad0c5