### PR TITLE
Fix RK3568 MMU attributes and comment

### DIFF
--- a/soc/rockchip/rk35/rk3568/Kconfig.defconfig
+++ b/soc/rockchip/rk35/rk3568/Kconfig.defconfig
@@ -6,4 +6,4 @@ if SOC_RK3568
 
 rsource "Kconfig.defconfig.rk3568"
 
-endif # SOC_SERIES_RK3568
+endif # SOC_RK3568

--- a/soc/rockchip/rk35/rk3568/mmu_regions.c
+++ b/soc/rockchip/rk35/rk3568/mmu_regions.c
@@ -14,12 +14,12 @@ static const struct arm_mmu_region mmu_regions[] = {
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 0),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 0),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_RW | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
 	MMU_REGION_FLAT_ENTRY("GIC",
 			      DT_REG_ADDR_BY_IDX(DT_NODELABEL(gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_NODELABEL(gic), 1),
-			      MT_DEVICE_nGnRnE | MT_P_RW_U_RW | MT_NS),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_NA | MT_NS),
 
 };
 


### PR DESCRIPTION
## Summary
- restrict RK3568 GIC access for user mode
- fix typo in RK3568 defconfig comment

## Testing
- `./scripts/checkpatch.pl --no-tree -f soc/rockchip/rk35/rk3568/mmu_regions.c soc/rockchip/rk35/rk3568/Kconfig.defconfig`
- `west build` *(fails: `west: unknown command "build"`)*

------
https://chatgpt.com/codex/tasks/task_e_6852ac12cf748321b23159624f53b108