### PR TITLE
Fix sign handling in Nordic sensors

### DIFF
--- a/drivers/sensor/nordic/npm2100_vbat/npm2100_vbat.c
+++ b/drivers/sensor/nordic/npm2100_vbat/npm2100_vbat.c
@@ -185,8 +185,7 @@ int npm2100_vbat_channel_get(const struct device *dev, enum sensor_channel chan,
 
 	int32_t tmp = scaling_off + ((int32_t)*result * scaling_mul) / scaling_div;
 
-	valp->val1 = tmp / 1000000;
-	valp->val2 = tmp % 1000000;
+	sensor_value_from_micro(valp, tmp);
 
 	return 0;
 }
@@ -244,7 +243,7 @@ int npm2100_vbat_sample_fetch(const struct device *dev, enum sensor_channel chan
 		}
 	}
 
-	/* Fetch previous DPS duration result before triggering new one.The time it takes to get
+	/* Fetch previous DPS duration result before triggering new one. The time it takes to get
 	 * the DPS duration depends on many factors and cannot be predicted here.
 	 */
 	ret = i2c_reg_read_byte_dt(&config->i2c, BOOST_DPSDUR, &data->dpsdur);

--- a/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c
@@ -106,12 +106,9 @@ static int qdec_nrfx_channel_get(const struct device *dev,
 	acc = data->fetched_acc;
 	irq_unlock(key);
 
-	val->val1 = (acc * FULL_ANGLE) / config->steps;
-	val->val2 = (acc * FULL_ANGLE) - (val->val1 * config->steps);
-	if (val->val2 != 0) {
-		val->val2 *= 1000000;
-		val->val2 /= config->steps;
-	}
+	int64_t angle = (int64_t)acc * FULL_ANGLE * 1000000 / config->steps;
+
+	sensor_value_from_micro(val, angle);
 
 	return 0;
 }
@@ -225,7 +222,6 @@ static int qdec_nrfx_pm_action(const struct device *dev, enum pm_device_action a
 		break;
 	default:
 		return -ENOTSUP;
-		break;
 	}
 
 	return 0;

--- a/drivers/sensor/nordic/temp/temp_nrf5.c
+++ b/drivers/sensor/nordic/temp/temp_nrf5.c
@@ -87,8 +87,7 @@ static int temp_nrf5_channel_get(const struct device *dev,
 	}
 
 	uval = data->sample * TEMP_NRF5_TEMP_SCALE;
-	val->val1 = uval / 1000000;
-	val->val2 = uval % 1000000;
+	sensor_value_from_micro(val, uval);
 
 	LOG_DBG("Temperature:%d,%d", val->val1, val->val2);
 


### PR DESCRIPTION
## Summary
- fix negative value handling using sensor_value_from_micro
- remove redundant break in qdec driver
- correct DPS duration comment spacing

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/sensor/nordic/temp/temp_nrf5.c drivers/sensor/nordic/npm2100_vbat/npm2100_vbat.c drivers/sensor/nordic/qdec_nrfx/qdec_nrfx.c`
- ❌ `west build -p auto -b qemu_x86 samples/hello_world` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852abe07cfc8321ab1031cbda44742e