### PR TITLE
Fix PM shell messages and device loop

### DIFF
--- a/subsys/pm/device_system_managed.c
+++ b/subsys/pm/device_system_managed.c
@@ -33,7 +33,8 @@ bool pm_suspend_devices(void)
 
 	num_susp = 0;
 
-	for (const struct device *dev = devs + devc - 1; dev >= devs; dev--) {
+	for (size_t i = devc; i-- > 0;) {
+		const struct device *dev = &devs[i];
 		int ret;
 
 		/*
@@ -67,9 +68,9 @@ bool pm_suspend_devices(void)
 
 void pm_resume_devices(void)
 {
-	for (int i = (num_susp - 1); i >= 0; i--) {
+	for (size_t i = num_susp; i-- > 0;) {
 		pm_device_action_run(TYPE_SECTION_START(pm_device_slots)[i],
-				    PM_DEVICE_ACTION_RESUME);
+	PM_DEVICE_ACTION_RESUME);
 	}
 
 	num_susp = 0;

--- a/subsys/pm/pm_shell.c
+++ b/subsys/pm/pm_shell.c
@@ -45,7 +45,7 @@ static int pm_cmd_suspend(const struct shell *sh, size_t argc, char *argv[])
 
 	ret = pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
 	if (ret < 0) {
-		shell_error(sh, "Device %s error: %d", "suspend", ret);
+		shell_error(sh, "Device %s error: %d", dev->name, ret);
 		return ret;
 	}
 
@@ -71,7 +71,7 @@ static int pm_cmd_resume(const struct shell *sh, size_t argc, char *argv[])
 
 	ret = pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
 	if (ret < 0) {
-		shell_error(sh, "Device %s error: %d", "resume", ret);
+		shell_error(sh, "Device %s error: %d", dev->name, ret);
 		return ret;
 	}
 
@@ -97,7 +97,7 @@ static int pm_cmd_runtime_get(const struct shell *sh, size_t argc, char *argv[])
 
 	ret = pm_device_runtime_get(dev);
 	if (ret < 0) {
-		shell_error(sh, "Device %s error: %d", "runtime get", ret);
+		shell_error(sh, "Device %s error: %d", dev->name, ret);
 		return ret;
 	}
 
@@ -122,7 +122,7 @@ static int pm_cmd_runtime_put(const struct shell *sh, size_t argc, char *argv[])
 
 	ret = pm_device_runtime_put(dev);
 	if (ret < 0) {
-		shell_error(sh, "Device %s error: %d", "runtime put", ret);
+		shell_error(sh, "Device %s error: %d", dev->name, ret);
 		return ret;
 	}
 
@@ -147,7 +147,7 @@ static int pm_cmd_runtime_put_async(const struct shell *sh, size_t argc, char *a
 
 	ret = pm_device_runtime_put_async(dev, K_NO_WAIT);
 	if (ret < 0) {
-		shell_error(sh, "Device %s error: %d", "runtime put async", ret);
+		shell_error(sh, "Device %s error: %d", dev->name, ret);
 		return ret;
 	}
 


### PR DESCRIPTION
## Summary
- pm_shell: use device name when reporting errors
- device_system_managed: avoid pointer underflow when walking device list

## Testing
- `./scripts/checkpatch.pl --no-tree -f subsys/pm/pm_shell.c subsys/pm/device_system_managed.c`
- ❌ `west build -p auto -b qemu_x86 samples/hello_world` *(failed: west not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ea15a6e4832193b2358c13b6bf64