### PR TITLE
Fix const arrays not marked static

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -45,8 +45,8 @@ static const struct can_shell_mode_mapping can_shell_mode_map[] = {
 };
 
 K_MSGQ_DEFINE(can_shell_tx_msgq, sizeof(struct can_shell_tx_event),
-	      CONFIG_CAN_SHELL_TX_QUEUE_SIZE, 4);
-const struct shell *can_shell_tx_msgq_sh;
+             CONFIG_CAN_SHELL_TX_QUEUE_SIZE, 4);
+static const struct shell *can_shell_tx_msgq_sh;
 static struct k_work_poll can_shell_tx_msgq_work;
 static struct k_poll_event can_shell_tx_msgq_events[] = {
 	K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_MSGQ_DATA_AVAILABLE,
@@ -55,8 +55,8 @@ static struct k_poll_event can_shell_tx_msgq_events[] = {
 };
 
 K_MSGQ_DEFINE(can_shell_rx_msgq, sizeof(struct can_shell_rx_event),
-	      CONFIG_CAN_SHELL_RX_QUEUE_SIZE, 4);
-const struct shell *can_shell_rx_msgq_sh;
+             CONFIG_CAN_SHELL_RX_QUEUE_SIZE, 4);
+static const struct shell *can_shell_rx_msgq_sh;
 static struct k_work_poll can_shell_rx_msgq_work;
 static struct k_poll_event can_shell_rx_msgq_events[] = {
 	K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_MSGQ_DATA_AVAILABLE,

--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -56,7 +56,7 @@ struct state {
  * the members of 'struct state'.
  */
 
-const uint8_t addrs[] = { 0, 2, 4, 7, 8, 9, 10, 11 };
+static const uint8_t addrs[] = { 0, 2, 4, 7, 8, 9, 10, 11 };
 
 /*
  * Interesting bits in 'struct state'.

--- a/drivers/crypto/crypto_mchp_xec_symcr.c
+++ b/drivers/crypto/crypto_mchp_xec_symcr.c
@@ -148,7 +148,7 @@ struct hash_alg_to_rom {
 	enum mchp_rom_hash_alg_id rom_algo;
 };
 
-const struct hash_alg_to_rom hash_alg_tbl[] = {
+static const struct hash_alg_to_rom hash_alg_tbl[] = {
 	{ CRYPTO_HASH_ALGO_SHA224, MCHP_ROM_HASH_ALG_SHA224 },
 	{ CRYPTO_HASH_ALGO_SHA256, MCHP_ROM_HASH_ALG_SHA256 },
 	{ CRYPTO_HASH_ALGO_SHA384, MCHP_ROM_HASH_ALG_SHA384 },

--- a/drivers/crypto/crypto_rts5912_sha.c
+++ b/drivers/crypto/crypto_rts5912_sha.c
@@ -340,7 +340,7 @@ static DEVICE_API(crypto, rts5912_hash_funcs) = {
 	.query_hw_caps = rts5912_query_hw_caps,
 };
 
-const struct rts5912_sha_config cfg_0 = {
+static const struct rts5912_sha_config cfg_0 = {
 	.cfg_sha2_regs = (volatile struct sha2_type *)DT_INST_REG_ADDR_BY_NAME(0, sha2),
 	.cfg_sha2dma_regs = (volatile struct sha2dma_type *)DT_INST_REG_ADDR_BY_NAME(0, sha2dma),
 };

--- a/drivers/i3c/i3c_mem_slab.c
+++ b/drivers/i3c/i3c_mem_slab.c
@@ -17,7 +17,7 @@ LOG_MODULE_DECLARE(i3c, CONFIG_I3C_LOG_LEVEL);
 	{                                                                                          \
 		.name = "unknown-" STRINGIFY(i)                                                    \
 	}
-const struct device dummy_devs[] = {
+static const struct device dummy_devs[] = {
 	LISTIFY(CONFIG_I3C_NUM_OF_DESC_MEM_SLABS, UNKNOWN_NAME_STR, (,)) };
 
 K_MEM_SLAB_DEFINE(i3c_device_desc_pool, sizeof(struct i3c_device_desc),

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -98,7 +98,7 @@ DT_FOREACH_STATUS_OKAY(st_stm32_i3c, I3C_CTRL_FN)
 			    .i3c_list_dev_subcmd = &node_id##sub_i3c_list,))                       \
 	},
 
-const struct i3c_ctrl i3c_list[] = {
+static const struct i3c_ctrl i3c_list[] = {
 	/* zephyr-keep-sorted-start */
 	DT_FOREACH_STATUS_OKAY(cdns_i3c, I3C_CTRL_LIST_ENTRY)
 	DT_FOREACH_STATUS_OKAY(ite_it51xxx_i3cm, I3C_CTRL_LIST_ENTRY)

--- a/drivers/mfd/mfd_axp192.c
+++ b/drivers/mfd/mfd_axp192.c
@@ -118,7 +118,7 @@ struct mfd_axp192_func_reg_desc {
 	uint8_t mask;
 };
 
-const struct mfd_axp192_func_reg_desc gpio_reg_desc[AXP192_GPIO_MAX_NUM] = {
+static const struct mfd_axp192_func_reg_desc gpio_reg_desc[AXP192_GPIO_MAX_NUM] = {
 	{
 		/* GPIO0 */
 		.reg = AXP192_GPIO0_FUNC_REG,

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -606,7 +606,7 @@ static int spi_stm32_configure(const struct device *dev,
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
-	const uint32_t scaler[] = {
+       static const uint32_t scaler[] = {
 		LL_SPI_BAUDRATEPRESCALER_DIV2,
 		LL_SPI_BAUDRATEPRESCALER_DIV4,
 		LL_SPI_BAUDRATEPRESCALER_DIV8,

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -112,11 +112,11 @@ static void qmspi_set_frequency(QMSPI_Type *regs, uint32_t freq_hz)
  *  Mode 3: CPOL=1 CHPA=1 (CHPA_MISO=0 and CHPA_MOSI=1)
  */
 
-const uint8_t smode_tbl[4] = {
+static const uint8_t smode_tbl[4] = {
 	0x00u, 0x06u, 0x01u, 0x07u
 };
 
-const uint8_t smode48_tbl[4] = {
+static const uint8_t smode48_tbl[4] = {
 	0x04u, 0x02u, 0x05u, 0x03u
 };
 

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -238,7 +238,7 @@ static int qmspi_set_frequency(struct spi_qmspi_data *qdata, struct qmspi_regs *
  * set CHPA_MISO=0 for SPI Mode 3 at all frequencies.
  */
 
-const uint8_t smode_tbl[4] = {
+static const uint8_t smode_tbl[4] = {
 	0x00u, 0x06u, 0x01u,
 #ifdef XEC_QMSPI_SPI_MODE_3_ANOMALY
 	0x03u, /* CPOL=1, CPHA_MOSI=1, CPHA_MISO=0 */
@@ -247,7 +247,7 @@ const uint8_t smode_tbl[4] = {
 #endif
 };
 
-const uint8_t smode48_tbl[4] = {
+static const uint8_t smode48_tbl[4] = {
 	0x04u, 0x02u, 0x05u, 0x03u
 };
 

--- a/drivers/usb/device/usb_dc_rpi_pico.c
+++ b/drivers/usb/device/usb_dc_rpi_pico.c
@@ -59,7 +59,8 @@ struct udc_rpi_ep_state {
 		    ((void *)PINCTRL_DT_INST_DEV_CONFIG_GET(n)), (NULL))
 
 USB_RPI_PICO_PINCTRL_DT_INST_DEFINE(0);
-const struct pinctrl_dev_config *pcfg = USB_RPI_PICO_PINCTRL_DT_INST_DEV_CONFIG_GET(0);
+static const struct pinctrl_dev_config *pcfg =
+	USB_RPI_PICO_PINCTRL_DT_INST_DEV_CONFIG_GET(0);
 
 #define USBD_THREAD_STACK_SIZE 1024
 

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -747,7 +747,7 @@ static void eswifi_off_freeaddrinfo(struct zsock_addrinfo *res)
 	free(res);
 }
 
-const struct socket_dns_offload eswifi_dns_ops = {
+static const struct socket_dns_offload eswifi_dns_ops = {
 	.getaddrinfo = eswifi_off_getaddrinfo,
 	.freeaddrinfo = eswifi_off_freeaddrinfo,
 };

--- a/drivers/wifi/nrf_wifi/src/coex.c
+++ b/drivers/wifi/nrf_wifi/src/coex.c
@@ -48,7 +48,7 @@ static struct nrf_wifi_ctx_zep *rpu_ctx = &rpu_drv_priv_zep.rpu_ctx_zep;
 
 /* PTA registers configuration of Coexistence Hardware */
 /* Separate antenna configuration, WLAN in 2.4GHz. For BLE protocol. */
-const uint16_t config_buffer_SEA_ble[] = {
+static const uint16_t config_buffer_SEA_ble[] = {
 	0x0019, 0x00F6, 0x0008, 0x0062, 0x00F5,
 	0x00F5, 0x0019, 0x0019, 0x0074, 0x0074,
 	0x0008, 0x01E2, 0x00D5, 0x00D5, 0x01F6,
@@ -61,7 +61,7 @@ const uint16_t config_buffer_SEA_ble[] = {
 };
 
 /* Separate antenna configuration, WLAN in 2.4GHz. For non BLE protocol */
-const uint16_t config_buffer_SEA_non_ble[] = {
+static const uint16_t config_buffer_SEA_non_ble[] = {
 	0x0019, 0x00F6, 0x0008, 0x0062, 0x00F5,
 	0x00F5, 0x0061, 0x0061, 0x0074, 0x0074,
 	0x01E2, 0x01E2, 0x00D5, 0x00D5, 0x01F6,
@@ -74,7 +74,7 @@ const uint16_t config_buffer_SEA_non_ble[] = {
 };
 
 /* Shared antenna configuration, WLAN in 2.4GHz. */
-const uint16_t config_buffer_SHA[] = {
+static const uint16_t config_buffer_SHA[] = {
 	0x0019, 0x00F6, 0x0008, 0x00E2, 0x0015,
 	0x00F5, 0x0019, 0x0019, 0x0004, 0x01F6,
 	0x0008, 0x01E2, 0x00F5, 0x00F5, 0x01F6,
@@ -87,7 +87,7 @@ const uint16_t config_buffer_SHA[] = {
 };
 
 /* Shared/separate antennas, WLAN in 5GHz */
-const uint16_t config_buffer_5G[] = {
+static const uint16_t config_buffer_5G[] = {
 	0x0039, 0x0076, 0x0028, 0x0062, 0x0075,
 	0x0075, 0x0061, 0x0061, 0x0074, 0x0074,
 	0x0060, 0x0060, 0x0075, 0x0075, 0x0064,
@@ -101,7 +101,7 @@ const uint16_t config_buffer_5G[] = {
 
 /* non-PTA register configuration of coexistence hardware */
 /* Shared antenna */
-const uint32_t ch_config_sha[] = {
+static const uint32_t ch_config_sha[] = {
 	0x00000028, 0x00000000, 0x001e1023, 0x00000000, 0x00000000,
 	0x00000000, 0x00000021, 0x000002ca, 0x0000005A, 0x00000000,
 	0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
@@ -109,7 +109,7 @@ const uint32_t ch_config_sha[] = {
 };
 
 /* Separate antennas. For BLE protocol. */
-const uint32_t ch_config_sep_ble[] = {
+static const uint32_t ch_config_sep_ble[] = {
 	0x00000028, 0x00000000, 0x001e1023, 0x00000000, 0x00000000,
 	0x00000000, 0x00000021, 0x000002ca, 0x00000055, 0x00000000,
 	0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
@@ -117,7 +117,7 @@ const uint32_t ch_config_sep_ble[] = {
 };
 
 /* Separate antennas. For non BLE protocol. */
-const uint32_t ch_config_sep_non_ble[] = {
+static const uint32_t ch_config_sep_non_ble[] = {
 	0x00000028, 0x00000000, 0x001e1023, 0x00000000, 0x00000000,
 	0x00000000, 0x00000021, 0x000002ca, 0x00000055, 0x00000000,
 	0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000,


### PR DESCRIPTION
## Summary
- scope down constant tables in various drivers

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/usb/device/usb_dc_rpi_pico.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: unknown command)*

------
https://chatgpt.com/codex/tasks/task_e_685300691aec83218aa48a1de6e786da