### PR TITLE
drivers: mark constant tables as static

### DIFF
--- a/drivers/clock_control/clock_control_npcm.c
+++ b/drivers/clock_control/clock_control_npcm.c
@@ -356,7 +356,7 @@ static int npcm_clock_control_init(const struct device *dev)
 	return 0;
 }
 
-const struct npcm_pcc_config pcc_config = {
+static const struct npcm_pcc_config pcc_config = {
 	.base_cdcg = DT_INST_REG_ADDR_BY_NAME(0, cdcg),
 	.base_pmc = DT_INST_REG_ADDR_BY_NAME(0, pmc),
 };

--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -14,7 +14,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ipm_console, CONFIG_IPM_LOG_LEVEL);
 
-const struct device *ipm_dev;
+static const struct device *ipm_dev;
 
 static int console_out(int c)
 {

--- a/drivers/crypto/crypto_mchp_xec_symcr.c
+++ b/drivers/crypto/crypto_mchp_xec_symcr.c
@@ -148,7 +148,7 @@ struct hash_alg_to_rom {
 	enum mchp_rom_hash_alg_id rom_algo;
 };
 
-const struct hash_alg_to_rom hash_alg_tbl[] = {
+static const struct hash_alg_to_rom hash_alg_tbl[] = {
 	{ CRYPTO_HASH_ALGO_SHA224, MCHP_ROM_HASH_ALG_SHA224 },
 	{ CRYPTO_HASH_ALGO_SHA256, MCHP_ROM_HASH_ALG_SHA256 },
 	{ CRYPTO_HASH_ALGO_SHA384, MCHP_ROM_HASH_ALG_SHA384 },

--- a/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
+++ b/drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(nxp_imx_eth);
 #define NETC_HAS_NO_SWITCH_TAG_SUPPORT 1
 #endif
 
-const struct device *netc_dev_list[NETC_DRV_MAX_INST_SUPPORT];
+static const struct device *netc_dev_list[NETC_DRV_MAX_INST_SUPPORT];
 
 static int netc_eth_rx(const struct device *dev)
 {

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -326,8 +326,8 @@ static int cmd_test(const struct shell *sh, size_t argc, char *argv[])
 }
 
 #ifdef CONFIG_FLASH_SHELL_TEST_COMMANDS
-const static uint8_t speed_types[][4] = { "B", "KiB", "MiB", "GiB" };
-const static uint32_t speed_divisor = 1024;
+static const uint8_t speed_types[][4] = { "B", "KiB", "MiB", "GiB" };
+static const uint32_t speed_divisor = 1024;
 
 static int read_write_erase_validate(const struct shell *sh, size_t argc, char *argv[],
 				     uint32_t *size, uint32_t *repeat)

--- a/drivers/gpio/gpio_davinci.c
+++ b/drivers/gpio/gpio_davinci.c
@@ -61,7 +61,7 @@ struct gpio_davinci_config {
 	const struct pinctrl_dev_config *pcfg;
 };
 
-const unsigned int offset_array[5] = {0x10, 0x38, 0x60, 0x88, 0xb0};
+static const unsigned int offset_array[5] = {0x10, 0x38, 0x60, 0x88, 0xb0};
 #define MAX_REGS_BANK ARRAY_SIZE(offset_array)
 
 #define BANK0 0

--- a/drivers/gpio/gpio_pca_series.c
+++ b/drivers/gpio/gpio_pca_series.c
@@ -56,7 +56,7 @@ enum gpio_pca_series_part_no {
  *
  * @note must be consistent in order with @ref enum gpio_pca_series_part_no
  */
-const char *const gpio_pca_series_part_name[] = {
+static const char *const gpio_pca_series_part_name[] = {
 	"pca9538",
 	"pca9539",
 	"pca9554",
@@ -103,7 +103,7 @@ enum gpio_pca_series_reg_type {			/** Type0 Type1 Type2 Type3 */
  *     port-level "pin output configuration" register.
  */
 
-const char *const gpio_pca_series_reg_name[] = {
+static const char *const gpio_pca_series_reg_name[] = {
 	"1b_input_port",
 	"1b_output_port",
 /*  "1b_polarity_inversion," */

--- a/drivers/i3c/i3c_mem_slab.c
+++ b/drivers/i3c/i3c_mem_slab.c
@@ -17,7 +17,7 @@ LOG_MODULE_DECLARE(i3c, CONFIG_I3C_LOG_LEVEL);
 	{                                                                                          \
 		.name = "unknown-" STRINGIFY(i)                                                    \
 	}
-const struct device dummy_devs[] = {
+static const struct device dummy_devs[] = {
 	LISTIFY(CONFIG_I3C_NUM_OF_DESC_MEM_SLABS, UNKNOWN_NAME_STR, (,)) };
 
 K_MEM_SLAB_DEFINE(i3c_device_desc_pool, sizeof(struct i3c_device_desc),

--- a/drivers/i3c/i3c_shell.c
+++ b/drivers/i3c/i3c_shell.c
@@ -98,7 +98,7 @@ DT_FOREACH_STATUS_OKAY(st_stm32_i3c, I3C_CTRL_FN)
 			    .i3c_list_dev_subcmd = &node_id##sub_i3c_list,))                       \
 	},
 
-const struct i3c_ctrl i3c_list[] = {
+static const struct i3c_ctrl i3c_list[] = {
 	/* zephyr-keep-sorted-start */
 	DT_FOREACH_STATUS_OKAY(cdns_i3c, I3C_CTRL_LIST_ENTRY)
 	DT_FOREACH_STATUS_OKAY(ite_it51xxx_i3cm, I3C_CTRL_LIST_ENTRY)

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -522,7 +522,7 @@ uint32_t SX127xGetDio1PinState(void)
 }
 
 /* Initialize Radio driver callbacks */
-const struct Radio_s Radio = {
+static const struct Radio_s Radio = {
 	.Init = SX127xInit,
 	.GetStatus = SX127xGetStatus,
 	.SetModem = SX127xSetModem,

--- a/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
+++ b/drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c
@@ -37,7 +37,7 @@ struct mcux_dcnano_lcdif_dbi_foramt_map_t {
 	lcdif_dbi_out_format_t format;
 };
 
-const struct mcux_dcnano_lcdif_dbi_foramt_map_t format_map[] = {
+static const struct mcux_dcnano_lcdif_dbi_foramt_map_t format_map[] = {
 	{MIPI_DBI_MODE_6800_BUS_8_BIT, MIPI_DBI_MODE_RGB332, kLCDIF_DbiOutD8RGB332},
 	{MIPI_DBI_MODE_6800_BUS_8_BIT, MIPI_DBI_MODE_RGB444, kLCDIF_DbiOutD8RGB444},
 	{MIPI_DBI_MODE_6800_BUS_8_BIT, MIPI_DBI_MODE_RGB565, kLCDIF_DbiOutD8RGB565},

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -112,11 +112,11 @@ static void qmspi_set_frequency(QMSPI_Type *regs, uint32_t freq_hz)
  *  Mode 3: CPOL=1 CHPA=1 (CHPA_MISO=0 and CHPA_MOSI=1)
  */
 
-const uint8_t smode_tbl[4] = {
+static const uint8_t smode_tbl[4] = {
 	0x00u, 0x06u, 0x01u, 0x07u
 };
 
-const uint8_t smode48_tbl[4] = {
+static const uint8_t smode48_tbl[4] = {
 	0x04u, 0x02u, 0x05u, 0x03u
 };
 

--- a/drivers/spi/spi_xec_qmspi_ldma.c
+++ b/drivers/spi/spi_xec_qmspi_ldma.c
@@ -238,7 +238,7 @@ static int qmspi_set_frequency(struct spi_qmspi_data *qdata, struct qmspi_regs *
  * set CHPA_MISO=0 for SPI Mode 3 at all frequencies.
  */
 
-const uint8_t smode_tbl[4] = {
+static const uint8_t smode_tbl[4] = {
 	0x00u, 0x06u, 0x01u,
 #ifdef XEC_QMSPI_SPI_MODE_3_ANOMALY
 	0x03u, /* CPOL=1, CPHA_MOSI=1, CPHA_MISO=0 */
@@ -247,7 +247,7 @@ const uint8_t smode_tbl[4] = {
 #endif
 };
 
-const uint8_t smode48_tbl[4] = {
+static const uint8_t smode48_tbl[4] = {
 	0x04u, 0x02u, 0x05u, 0x03u
 };
 

--- a/drivers/usb_c/tcpc/tcpci.c
+++ b/drivers/usb_c/tcpc/tcpci.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(tcpci, CONFIG_USBC_LOG_LEVEL);
 
 #define LOG_COMM_ERR_STR "Can't communicate with TCPC %s@%x (%s %x = %04x)"
 
-const struct tcpci_reg_dump_map tcpci_std_regs[TCPCI_STD_REGS_SIZE] = {
+static const struct tcpci_reg_dump_map tcpci_std_regs[TCPCI_STD_REGS_SIZE] = {
 	{
 		.addr = TCPC_REG_VENDOR_ID,
 		.name = "VENDOR_ID",

--- a/drivers/video/gc2145.c
+++ b/drivers/video/gc2145.c
@@ -1118,7 +1118,7 @@ static uint8_t gc2145_check_connection(const struct device *dev)
 #define GC2145_640_480_LINK_FREQ_ID	0
 #define GC2145_1600_1200_LINK_FREQ	240000000
 #define GC2145_1600_1200_LINK_FREQ_ID	1
-const int64_t gc2145_link_frequency[] = {
+static const int64_t gc2145_link_frequency[] = {
 	GC2145_640_480_LINK_FREQ, GC2145_1600_1200_LINK_FREQ,
 };
 static int gc2145_config_csi(const struct device *dev, uint32_t pixelformat,

--- a/drivers/video/video_mcux_mipi_csi2rx.c
+++ b/drivers/video/video_mcux_mipi_csi2rx.c
@@ -42,7 +42,7 @@ struct mipi_csi2rx_tHsSettleEscClk_config {
 };
 
 /* Must be in pixel rate ascending order */
-const struct mipi_csi2rx_tHsSettleEscClk_config tHsSettleEscClk_configs[] = {
+static const struct mipi_csi2rx_tHsSettleEscClk_config tHsSettleEscClk_configs[] = {
 	{MHZ(24), 0x24},
 	{MHZ(48), 0x12},
 	{MHZ(96), 0x09},

--- a/drivers/watchdog/wdt_cmsdk_apb.c
+++ b/drivers/watchdog/wdt_cmsdk_apb.c
@@ -63,7 +63,7 @@ struct wdog_cmsdk_apb {
 	((volatile struct wdog_cmsdk_apb *)(DT_INST_REG_ADDR(0)))
 
 /* Keep reference of the device to pass it to the callback */
-const struct device *wdog_r;
+static const struct device *wdog_r;
 
 /* watchdog reload value in clock cycles */
 static unsigned int reload_cycles = CMSDK_APB_WDOG_RELOAD;

--- a/drivers/watchdog/wdt_renesas_ra.c
+++ b/drivers/watchdog/wdt_renesas_ra.c
@@ -30,13 +30,13 @@ struct wdt_renesas_ra_data {
 #define WDT_RENESAS_RA_ATOMIC_TIMEOUT_SET (1)
 
 /* Lookup table for WDT period raw cycle */
-const float timeout_period_lut[] = {
+static const float timeout_period_lut[] = {
 	[WDT_TIMEOUT_128] = 128,    [WDT_TIMEOUT_512] = 512,   [WDT_TIMEOUT_1024] = 1024,
 	[WDT_TIMEOUT_2048] = 2048,  [WDT_TIMEOUT_4096] = 4096, [WDT_TIMEOUT_8192] = 8192,
 	[WDT_TIMEOUT_16384] = 16384};
 
 /* Lookup table for the division value of the input clock count */
-const float clock_div_lut[] = {[WDT_CLOCK_DIVISION_1] = 1,       [WDT_CLOCK_DIVISION_4] = 4,
+static const float clock_div_lut[] = {[WDT_CLOCK_DIVISION_1] = 1,       [WDT_CLOCK_DIVISION_4] = 4,
 			       [WDT_CLOCK_DIVISION_16] = 16,     [WDT_CLOCK_DIVISION_32] = 32,
 			       [WDT_CLOCK_DIVISION_64] = 64,     [WDT_CLOCK_DIVISION_128] = 128,
 			       [WDT_CLOCK_DIVISION_256] = 256,   [WDT_CLOCK_DIVISION_512] = 512,
@@ -45,13 +45,13 @@ const float clock_div_lut[] = {[WDT_CLOCK_DIVISION_1] = 1,       [WDT_CLOCK_DIVI
 #define WDT_WINDOW_INVALID (-1)
 
 /* Lookup table for the window start position setting */
-const int window_start_lut[] = {
+static const int window_start_lut[] = {
 	[0] = WDT_WINDOW_START_100, [1] = WDT_WINDOW_START_75, [2] = WDT_WINDOW_START_50,
 	[3] = WDT_WINDOW_START_25,  [4] = WDT_WINDOW_INVALID,
 };
 
 /* Lookup table for the window end position setting */
-const int window_end_lut[] = {
+static const int window_end_lut[] = {
 	[0] = WDT_WINDOW_INVALID, [1] = WDT_WINDOW_END_75, [2] = WDT_WINDOW_END_50,
 	[3] = WDT_WINDOW_END_25,  [4] = WDT_WINDOW_END_0,
 };


### PR DESCRIPTION
## Summary
- mark constant tables static so they reside in flash

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/clock_control/clock_control_npcm.c drivers/console/ipm_console.c drivers/crypto/crypto_mchp_xec_symcr.c drivers/ethernet/nxp_imx_netc/eth_nxp_imx_netc.c drivers/flash/flash_shell.c drivers/gpio/gpio_davinci.c drivers/gpio/gpio_pca_series.c drivers/i3c/i3c_mem_slab.c drivers/i3c/i3c_shell.c drivers/lora/sx127x.c drivers/mipi_dbi/mipi_dbi_nxp_dcnano_lcdif.c drivers/spi/spi_xec_qmspi.c drivers/spi/spi_xec_qmspi_ldma.c drivers/usb_c/tcpc/tcpci.c drivers/video/gc2145.c drivers/video/video_mcux_mipi_csi2rx.c drivers/watchdog/wdt_cmsdk_apb.c drivers/watchdog/wdt_renesas_ra.c`
- ❌ `west build -p auto -b qemu_x86 samples/hello_world` *(failed: CMake error)*


------
https://chatgpt.com/codex/tasks/task_e_685300691aec83218aa48a1de6e786da