### PR TITLE
Make several driver configs const

### DIFF
--- a/drivers/i2c/i2c_b91.c
+++ b/drivers/i2c/i2c_b91.c
@@ -165,7 +165,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 								      \
 	static struct i2c_b91_data i2c_b91_data_##inst;		      \
 								      \
-	static struct i2c_b91_cfg i2c_b91_cfg_##inst = {	      \
+	static const struct i2c_b91_cfg i2c_b91_cfg_##inst = {	      \
 		.bitrate = DT_INST_PROP(inst, clock_frequency),	      \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),	      \
 	};							      \

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -322,7 +322,7 @@ static DEVICE_API(i2c, i2c_emul_api) = {
 	static const struct i2c_dt_spec emul_forward_list_##n[] = {                                \
 		COND_CODE_1(DT_INST_NODE_HAS_PROP(n, forwards),                                    \
 			    (DT_INST_FOREACH_PROP_ELEM(n, forwards, EMUL_FORWARD_ITEM)), ())};     \
-	static struct i2c_emul_config i2c_emul_cfg_##n = {                                         \
+	static const struct i2c_emul_config i2c_emul_cfg_##n = {                                         \
 		.emul_list =                                                                       \
 			{                                                                          \
 				.children = emuls_##n,                                             \

--- a/drivers/i2c/i2c_sifive.c
+++ b/drivers/i2c/i2c_sifive.c
@@ -327,7 +327,7 @@ static DEVICE_API(i2c, i2c_sifive_api) = {
 /* Device instantiation */
 
 #define I2C_SIFIVE_INIT(n) \
-	static struct i2c_sifive_cfg i2c_sifive_cfg_##n = { \
+	static const struct i2c_sifive_cfg i2c_sifive_cfg_##n = { \
 		.base = DT_INST_REG_ADDR(n), \
 		.f_sys = SIFIVE_PERIPHERAL_CLOCK_FREQUENCY, \
 		.f_bus = DT_INST_PROP(n, clock_frequency), \

--- a/drivers/i2c/i2c_wch.c
+++ b/drivers/i2c/i2c_wch.c
@@ -411,7 +411,7 @@ static DEVICE_API(i2c, i2c_wch_api) = {
 											\
 	static void i2c_wch_config_func_##inst(const struct device *dev);		\
 											\
-	static struct i2c_wch_config i2c_wch_cfg_##inst = {				\
+	static const struct i2c_wch_config i2c_wch_cfg_##inst = {				\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),				\
 		.irq_config_func = i2c_wch_config_func_##inst,				\
 		.clk_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst)),			\

--- a/drivers/input/input_cap12xx.c
+++ b/drivers/input/input_cap12xx.c
@@ -47,7 +47,7 @@ struct cap12xx_config {
 	struct i2c_dt_spec i2c;
 	const uint8_t input_channels;
 	const uint16_t *input_codes;
-	struct gpio_dt_spec *int_gpio;
+       const struct gpio_dt_spec *int_gpio;
 	bool repeat;
 	const uint16_t poll_interval_ms;
 	const uint8_t sensor_gain;
@@ -308,7 +308,7 @@ static int cap12xx_init(const struct device *dev)
 
 #define CAP12XX_INIT(index)                                                                        \
 	IF_ENABLED(DT_INST_NODE_HAS_PROP(index, int_gpios), (                                      \
-	static struct gpio_dt_spec cap12xx_int_gpio_##index =                                      \
+	static const struct gpio_dt_spec cap12xx_int_gpio_##index =                                      \
 		GPIO_DT_SPEC_INST_GET(index, int_gpios);))                                         \
 	static const uint16_t cap12xx_input_codes_##index[] = DT_INST_PROP(index, input_codes);    \
 	static const uint8_t cap12xx_signal_guard_##index[] =                                      \

--- a/drivers/input/input_xec_kbd.c
+++ b/drivers/input/input_xec_kbd.c
@@ -229,7 +229,7 @@ static const struct input_kbd_matrix_api xec_kbd_api = {
 /* To enable wakeup, set the "wakeup-source" on the keyboard scanning device
  * node.
  */
-static struct xec_kbd_config xec_kbd_cfg_0 = {
+static const struct xec_kbd_config xec_kbd_cfg_0 = {
 	.common = INPUT_KBD_MATRIX_DT_INST_COMMON_CONFIG_INIT(0, &xec_kbd_api),
 	.regs = (struct kscan_regs *)(DT_INST_REG_ADDR(0)),
 	.girq = DT_INST_PROP_BY_IDX(0, girqs, 0),

--- a/drivers/mspi/mspi_ambiq_ap3.c
+++ b/drivers/mspi/mspi_ambiq_ap3.c
@@ -1411,7 +1411,7 @@ static DEVICE_API(mspi, mspi_ambiq_driver_api) = {
 	}                                                                                        \
 	static uint32_t mspi_ambiq_cmdq##n[DT_INST_PROP_OR(n, cmdq_buffer_size, 1024) / 4]       \
 	__attribute__((section(DT_INST_PROP_OR(n, cmdq_buffer_location, ".mspi_buff"))));        \
-	static struct gpio_dt_spec ce_gpios##n[] = MSPI_CE_GPIOS_DT_SPEC_INST_GET(n);            \
+	static const struct gpio_dt_spec ce_gpios##n[] = MSPI_CE_GPIOS_DT_SPEC_INST_GET(n);            \
 	static struct mspi_ambiq_data mspi_ambiq_data##n = {                                     \
 		.mspiHandle            = NULL,                                                   \
 		.hal_dev_cfg           = MSPI_HAL_DEVICE_CONFIG(n, mspi_ambiq_cmdq##n,           \

--- a/drivers/mspi/mspi_ambiq_ap5.c
+++ b/drivers/mspi/mspi_ambiq_ap5.c
@@ -1978,7 +1978,7 @@ static DEVICE_API(mspi, mspi_ambiq_driver_api) = {
 	}                                                                                        \
 	static uint32_t mspi_ambiq_cmdq##n[DT_INST_PROP_OR(n, cmdq_buffer_size, 1024)]           \
 	__attribute__((section(DT_INST_PROP_OR(n, cmdq_buffer_location, ".nocache"))));          \
-	static struct gpio_dt_spec ce_gpios##n[] = MSPI_CE_GPIOS_DT_SPEC_INST_GET(n);            \
+	static const struct gpio_dt_spec ce_gpios##n[] = MSPI_CE_GPIOS_DT_SPEC_INST_GET(n);            \
 	static struct mspi_ambiq_data mspi_ambiq_data##n = {                                     \
 		.mspiHandle            = NULL,                                                   \
 		.hal_cfg               = MSPI_HAL_CONFIG(n, mspi_ambiq_cmdq##n,                  \

--- a/drivers/mspi/mspi_emul.c
+++ b/drivers/mspi/mspi_emul.c
@@ -879,7 +879,7 @@ static struct emul_mspi_driver_api emul_mspi_driver_api = {
 		.children = emuls_##n,                                                            \
 		.num_children = ARRAY_SIZE(emuls_##n),                                            \
 	};                                                                                        \
-	static struct gpio_dt_spec ce_gpios##n[] = MSPI_CE_GPIOS_DT_SPEC_INST_GET(n);             \
+	static const struct gpio_dt_spec ce_gpios##n[] = MSPI_CE_GPIOS_DT_SPEC_INST_GET(n);             \
 	static struct mspi_emul_data mspi_emul_data_##n = {                                       \
 		.mspicfg               = MSPI_CONFIG(n),                                          \
 		.mspicfg.ce_group      = (struct gpio_dt_spec *)ce_gpios##n,                      \

--- a/drivers/virtio/virtio_mmio.c
+++ b/drivers/virtio/virtio_mmio.c
@@ -310,7 +310,7 @@ static int virtio_mmio_init_common(const struct device *dev)
 
 #define VIRTIO_MMIO_DEFINE(inst)                                                                   \
 	static struct virtio_mmio_data virtio_mmio_data##inst;                                     \
-	static struct virtio_mmio_config virtio_mmio_config##inst = {                              \
+	static const struct virtio_mmio_config virtio_mmio_config##inst = {                              \
 		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(inst)),                           \
 	};                                                                                         \
 	static int virtio_mmio_init##inst(const struct device *dev)                                \

--- a/drivers/virtio/virtio_pci.c
+++ b/drivers/virtio/virtio_pci.c
@@ -583,7 +583,7 @@ static const struct virtio_driver_api virtio_pci_driver_api = {
 	BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_INST_PARENT(inst), pcie_controller));        \
 	DEVICE_PCIE_INST_DECLARE(inst);                                                 \
 	static struct virtio_pci_data virtio_pci_data##inst;                            \
-	static struct virtio_pci_config virtio_pci_config##inst = {                     \
+	static const struct virtio_pci_config virtio_pci_config##inst = {                     \
 		DEVICE_PCIE_INST_INIT(inst, pcie)                                           \
 	};                                                                              \
 	static int virtio_pci_init##inst(const struct device *dev)                      \


### PR DESCRIPTION
## Summary
- clean up driver config structures by marking them `static const`
- update CAP12XX driver to use const gpio spec pointers

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/virtio/virtio_mmio.c drivers/virtio/virtio_pci.c drivers/input/input_cap12xx.c drivers/mspi/mspi_ambiq_ap5.c drivers/mspi/mspi_ambiq_ap3.c drivers/mspi/mspi_emul.c drivers/i2c/i2c_emul.c drivers/i2c/i2c_b91.c drivers/i2c/i2c_sifive.c drivers/i2c/i2c_wch.c drivers/input/input_xec_kbd.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: 'drivers/i2c/target/Kconfig' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853000d3ee48321b5b1d09795a36a38