### PR TITLE
Fix style issues in Gecko hwinfo driver

### DIFF
--- a/drivers/hwinfo/hwinfo_gecko.c
+++ b/drivers/hwinfo/hwinfo_gecko.c
@@ -12,10 +12,10 @@
 #include <zephyr/sys/byteorder.h>
 
 #if defined(RMU_RSTCAUSE_BODUNREGRST) || defined(RMU_RSTCAUSE_BODREGRST) || \
-    defined(RMU_RSTCAUSE_AVDDBOD) || defined(RMU_RSTCAUSE_DVDDBOD) || \
-    defined(RMU_RSTCAUSE_DECBOD) || defined(RMU_RSTCAUSE_BODAVDD0) || \
-    defined(RMU_RSTCAUSE_BODAVDD1) || \
-    (defined(BU_PRESENT) && defined(_SILICON_LABS_32B_SERIES_0))
+	defined(RMU_RSTCAUSE_AVDDBOD) || defined(RMU_RSTCAUSE_DVDDBOD) || \
+	defined(RMU_RSTCAUSE_DECBOD) || defined(RMU_RSTCAUSE_BODAVDD0) || \
+	defined(RMU_RSTCAUSE_BODAVDD1) || \
+	(defined(BU_PRESENT) && defined(_SILICON_LABS_32B_SERIES_0))
 #define HAS_BROWNOUT 1
 #endif
 


### PR DESCRIPTION
## Summary
- fix indentation with tabs in Gecko hwinfo driver

## Testing
- `scripts/checkpatch.pl --no-tree -f $(cat /tmp/hwinfo_files.txt)`

------
https://chatgpt.com/codex/tasks/task_e_6852fff1c9388321a41303030ab073c5