### PR TITLE
Fix Renesas RZ IRQ access

### DIFF
--- a/soc/renesas/rz/rzn2l/soc.c
+++ b/soc/renesas/rz/rzn2l/soc.c
@@ -25,7 +25,7 @@ void soc_reset_hook(void)
 {
 	/* Enable peripheral port access at EL1 and EL0 */
 	__asm__ volatile("mrc p15, 0, r0, c15, c0, 0\n");
-	__asm__ volatile("orr r0, #1\n");
+__asm__ volatile("orr r0, r0, #1\n");
 	__asm__ volatile("mcr p15, 0, r0, c15, c0, 0\n");
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();

--- a/soc/renesas/rz/rzt2l/soc.c
+++ b/soc/renesas/rz/rzt2l/soc.c
@@ -20,7 +20,7 @@ void soc_reset_hook(void)
 {
 	/* Enable peripheral port access at EL1 and EL0 */
 	__asm__ volatile("mrc p15, 0, r0, c15, c0, 0\n");
-	__asm__ volatile("orr r0, #1\n");
+__asm__ volatile("orr r0, r0, #1\n");
 	__asm__ volatile("mcr p15, 0, r0, c15, c0, 0\n");
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();

--- a/soc/renesas/rz/rzt2m/soc.c
+++ b/soc/renesas/rz/rzt2m/soc.c
@@ -21,7 +21,7 @@ void soc_reset_hook(void)
 {
 	/* Enable peripheral port access at EL1 and EL0 */
 	__asm__ volatile("mrc p15, 0, r0, c15, c0, 0\n");
-	__asm__ volatile("orr r0, #1\n");
+__asm__ volatile("orr r0, r0, #1\n");
 	__asm__ volatile("mcr p15, 0, r0, c15, c0, 0\n");
 	barrier_dsync_fence_full();
 	barrier_isync_fence_full();


### PR DESCRIPTION
## Summary
- fix assembly syntax in Renesas RZ SoC reset hooks

## Testing
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: drivers/i2c/Kconfig missing)*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: drivers/i2c/Kconfig missing)*
- `west build -p auto -b native_posix samples/hello_world` *(fails: Invalid BOARD)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: drivers/i2c/Kconfig missing)*
- `west build -t run` *(fails: drivers/i2c/Kconfig missing)*
- `./scripts/checkpatch.pl --no-tree -f soc/renesas/rz/rzn2l/soc.c soc/renesas/rz/rzt2m/soc.c soc/renesas/rz/rzt2l/soc.c`


------
https://chatgpt.com/codex/tasks/task_e_6853b0c0c4608321af5c04b009d49118