### PR TITLE
Fix periodSet argument in Renesas RZ GTM driver

### DIFF
--- a/drivers/counter/counter_renesas_rz_gtm.c
+++ b/drivers/counter/counter_renesas_rz_gtm.c
@@ -411,7 +411,7 @@ static int counter_rz_gtm_set_top_value(const struct device *dev,
 	}
 	/* timer already in interval mode - only change top value */
 	data->fsp_cfg->period_counts = data->top_val;
-	cfg->fsp_api->periodSet(&data->fsp_ctrl, data->fsp_cfg->period_counts);
+	cfg->fsp_api->periodSet(data->fsp_ctrl, data->fsp_cfg->period_counts);
 
 	/* check if counter reset is required */
 	if (top_cfg->flags & COUNTER_TOP_CFG_DONT_RESET) {


### PR DESCRIPTION
## Summary
- fix wrong pointer usage in `counter_renesas_rz_gtm.c`

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/counter/counter_renesas_rz_gtm.c`
- `west init -l .` *(fails: west update requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6853b0c0c4608321af5c04b009d49118