### PR TITLE
Add additional sensors to build_all tests

### DIFF
--- a/tests/drivers/build_all/sensor/adc.dtsi
+++ b/tests/drivers/build_all/sensor/adc.dtsi
@@ -19,9 +19,9 @@ test_adc_mcp9700a: mcp9700a {
 test_voltage: voltage {
 	status = "okay";
 	compatible = "voltage-divider";
-	io-channels = <&test_adc 1>;
-	io-channel-names = "VOLTAGE";
-	output-ohms = <47000>; /* R1 */
+		io-channels = <&test_adc 1>;
+		io-channel-names = "VOLTAGE";
+		output-ohms = <47000>; /* R1 */
 	full-ohms = <(100000 + 47000)>; /* R2 + R1 */
 	power-gpios = <&test_gpio 0 0>;
 };
@@ -119,11 +119,22 @@ test_seeed_grove_temperature: seeed-grove-temperature {
 };
 
 test_veaa_x_3: test_veaa_x_3 {
-	status = "okay";
-	compatible = "festo,veaa-x-3";
-	io-channels = <&test_adc 3>;
-	dac = <&test_dac>;
-	dac-channel-id = <2>;
-	dac-resolution = <12>;
-	pressure-range-type = "D2";
+        status = "okay";
+        compatible = "festo,veaa-x-3";
+        io-channels = <&test_adc 3>;
+        dac = <&test_dac>;
+        dac-channel-id = <2>;
+        dac-resolution = <12>;
+        pressure-range-type = "D2";
 };
+
+	test_adc_als_pt19: als_pt19 {
+	compatible = "everlight,als-pt19";
+	io-channels = <&test_adc 0>;
+	load-resistor = <15000>;
+	};
+
+	test_rpi_pico_temp: rpi_pico_temp {
+	compatible = "raspberrypi,pico-temp";
+	io-channels = <&test_adc 0>;
+	};

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -163,21 +163,26 @@
 			#include "uart.dtsi"
 		};
 
-		test_w1: w1@66660000 {
-			compatible = "vnd,w1";
-			reg = <0x66660000 0x1000>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			status = "okay";
+                test_w1: w1@66660000 {
+                        compatible = "vnd,w1";
+                        reg = <0x66660000 0x1000>;
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+                        status = "okay";
 
-			#include "w1.dtsi"
+                        #include "w1.dtsi"
+                };
+
+		test_xmc4xxx_temp: xmc4xxx_temp {
+			compatible = "infineon,xmc4xxx-temp";
+			status = "okay";
 		};
 
-		test_i3c: i3c@f0cacc1a {
-			#address-cells = <3>;
-			#size-cells = <0>;
-			compatible = "vnd,i3c";
-			reg = <0xf0cacc1a 0x1000>;
+                test_i3c: i3c@f0cacc1a {
+                        #address-cells = <3>;
+                        #size-cells = <0>;
+                        compatible = "vnd,i3c";
+                        reg = <0xf0cacc1a 0x1000>;
 			status = "okay";
 
 			#include "i3c.dtsi"

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1328,6 +1328,16 @@ test_i2c_bh1790: bh1790@b3 {
 };
 
 test_i2c_bh1730: bh1730@b4 {
-	compatible = "rohm,bh1730";
-	reg = <0xb4>;
+        compatible = "rohm,bh1730";
+        reg = <0xb4>;
 };
+
+test_i2c_icm40627: icm40627@b5 {
+	compatible = "invensense,icm40627";
+	reg = <0xb5>;
+	int-gpios = <&test_gpio 0 0>;
+	accel-hz = <100>;
+	gyro-hz = <100>;
+	accel-fs = <4>;
+	gyro-fs = <250>;
+	};

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -433,11 +433,23 @@ test_spi_icp201xx: icp201xx@34 {
 };
 
 test_spi_ad2s1210: ad2s1210@35 {
-	compatible = "adi,ad2s1210";
-	reg = <0x35>;
-	spi-max-frequency = <0>;
-	sample-gpios = <&test_gpio 0 (GPIO_ACTIVE_LOW)>;
-	mode-gpios = <&test_gpio 1 (GPIO_ACTIVE_HIGH)>, <&test_gpio 2 (GPIO_ACTIVE_HIGH)>;
-	reset-gpios = <&test_gpio 7 (GPIO_ACTIVE_LOW)>;
-	clock-frequency = <8192000>;
+        compatible = "adi,ad2s1210";
+        reg = <0x35>;
+        spi-max-frequency = <0>;
+        sample-gpios = <&test_gpio 0 (GPIO_ACTIVE_LOW)>;
+        mode-gpios = <&test_gpio 1 (GPIO_ACTIVE_HIGH)>, <&test_gpio 2 (GPIO_ACTIVE_HIGH)>;
+        reset-gpios = <&test_gpio 7 (GPIO_ACTIVE_LOW)>;
+        clock-frequency = <8192000>;
 };
+
+test_spi_afbr_s50: afbr_s50@36 {
+	compatible = "brcm,afbr-s50";
+	reg = <0x36>;
+	spi-max-frequency = <0>;
+	int-gpios = <&test_gpio 0 0>;
+	spi-mosi-gpios = <&test_gpio 0 0>;
+	spi-sck-gpios = <&test_gpio 0 0>;
+	spi-miso-gpios = <&test_gpio 0 0>;
+	measurement-mode = <1>;
+	dual-freq-mode = <0>;
+	};


### PR DESCRIPTION
## Summary
- add AFBR-S50 ToF sensor in SPI overlay
- add ICM-40627 motion sensor in I2C overlay
- include ALS-PT19 and Pico temperature sensors under ADC overlay
- provide XMC4XXX temperature sensor node

## Testing
- `west` build commands *(failed: command not found)*
- `./scripts/checkpatch.pl --no-tree -f tests/drivers/build_all/sensor/spi.dtsi tests/drivers/build_all/sensor/i2c.dtsi tests/drivers/build_all/sensor/adc.dtsi tests/drivers/build_all/sensor/app.overlay`

------
https://chatgpt.com/codex/tasks/task_e_685447158c6c8321affd8e9ecb352602