### PR TITLE
Fix SHT3XD threshold clear register

### DIFF
--- a/drivers/sensor/sensirion/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sensirion/sht3xd/sht3xd_trigger.c
@@ -233,7 +233,7 @@ int sht3xd_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-	if (sht3xd_write_reg(dev, SHT3XD_CMD_WRITE_TH_LOW_SET, 0) < 0) {
+	if (sht3xd_write_reg(dev, SHT3XD_CMD_WRITE_TH_LOW_CLEAR, 0) < 0) {
 		LOG_DBG("Failed to write threshold low clear value!");
 		return -EIO;
 	}


### PR DESCRIPTION
## Summary
- fix SHT3XD driver to use WRITE_TH_LOW_CLEAR when initializing trigger thresholds

## Testing
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: west not found)*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: west not found)*
- `west build -p auto -b native_posix samples/hello_world` *(fails: west not found)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: west not found)*
- `west build -t run` *(fails: west not found)*
- `./scripts/checkpatch.pl --no-tree -f drivers/sensor/sensirion/sht3xd/sht3xd_trigger.c`


------
https://chatgpt.com/codex/tasks/task_e_685483e306a083218770ecb595c24fc5