### PR TITLE
Fix mmc56x3 auto reset config

### DIFF
--- a/drivers/sensor/memsic/mmc56x3/mmc56x3.c
+++ b/drivers/sensor/memsic/mmc56x3/mmc56x3.c
@@ -357,7 +357,7 @@ static int mmc56x3_chip_configure(const struct device *dev, struct mmc56x3_confi
 	}
 
 	if (new_config->auto_sr != config->auto_sr) {
-		ret = mmc56x3_chip_set_auto_self_reset(dev, config->auto_sr);
+		ret = mmc56x3_chip_set_auto_self_reset(dev, new_config->auto_sr);
 	}
 
 	return ret;
@@ -366,7 +366,8 @@ static int mmc56x3_chip_configure(const struct device *dev, struct mmc56x3_confi
 static int mmc56x3_attr_set(const struct device *dev, enum sensor_channel chan,
 			    enum sensor_attribute attr, const struct sensor_value *val)
 {
-	struct mmc56x3_config new_config = {};
+	struct mmc56x3_data *data = dev->data;
+	struct mmc56x3_config new_config = data->config;
 	int ret = 0;
 
 	__ASSERT_NO_MSG(val != NULL);


### PR DESCRIPTION
## Summary
- fix auto reset configuration value in mmc56x3 driver
- initialize new configuration from current settings

## Testing
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: unknown command)*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: unknown command)*
- `west build -p auto -b native_posix samples/hello_world` *(fails: unknown command)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: unknown command)*
- `./scripts/checkpatch.pl --no-tree -f drivers/sensor/memsic/mmc56x3/mmc56x3.c`

------
https://chatgpt.com/codex/tasks/task_e_6855bf1c42c48321a6d6cf6468489b11