### PR TITLE
Remove offensive comment

### DIFF
--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -2283,7 +2283,7 @@ reexecute:
 
 		case s_chunk_parameters: {
 			__ASSERT_NO_MSG(parser->flags & F_CHUNKED);
-			/* just ignore this shit. TODO check for overflow */
+			/* ignore this for now. TODO check for overflow */
 			if (ch == CR) {
 				UPDATE_STATE(s_chunk_size_almost_done);
 				break;


### PR DESCRIPTION
## Summary
- sanitize comment language in http_parser

## Testing
- `./scripts/checkpatch.pl --no-tree -f subsys/net/lib/http/http_parser.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: drivers/i2c/target/Kconfig not found)*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: drivers/i2c/target/Kconfig not found)*
- `west build -p auto -b native_sim samples/hello_world` *(fails: drivers/i2c/target/Kconfig not found)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: drivers/i2c/target/Kconfig not found)*
- `west build -t run` *(fails: command exited with status 1)*


------
https://chatgpt.com/codex/tasks/task_e_6855bf23f9f8832187961dace3e9d486