### PR TITLE
Fix missing return check in settings_zms

### DIFF
--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -644,7 +644,7 @@ static int settings_zms_get_last_hash_ids(struct settings_zms *cf)
 			}
 			/* Now recover the linked list */
 			settings_element.previous_hash = previous_ll_hash_id;
-			zms_write(&cf->cf_zms, ll_last_hash_id, &settings_element,
+			rc = zms_write(&cf->cf_zms, ll_last_hash_id, &settings_element,
 				  sizeof(struct settings_hash_linked_list));
 			if (rc < 0) {
 				return rc;


### PR DESCRIPTION
## Summary
- fix lost rc assignment when recovering linked list

## Testing
- `./scripts/checkpatch.pl --no-tree -f subsys/settings/src/settings_zms.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: 'drivers/i2c/target/Kconfig' not found)*
- `cd doc && make html` *(fails: Could NOT find Doxygen)*

------
https://chatgpt.com/codex/tasks/task_e_6857a7273cc88321aebeaa225f223110