### PR TITLE
Fix uninitialized fmt struct in OV9655 init

### DIFF
--- a/drivers/video/ov9655.c
+++ b/drivers/video/ov9655.c
@@ -326,7 +326,7 @@ static int ov9655_get_fmt(const struct device *dev, struct video_format *fmt)
 static int ov9655_init(const struct device *dev)
 {
 	const struct ov9655_config *config = dev->config;
-	struct video_format fmt;
+	struct video_format fmt = { 0 };
 	uint32_t pid;
 	int ret;
 


### PR DESCRIPTION
## Summary
- initialize the `video_format` struct in `ov9655_init`

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/video/ov9655.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: 'drivers/i2c/target/Kconfig' not found)*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: 'drivers/i2c/target/Kconfig' not found)*
- `west build -p auto -b native_posix samples/hello_world` *(fails: Invalid BOARD)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: 'drivers/i2c/target/Kconfig' not found)*
- `west build -t run` *(fails: 'drivers/i2c/target/Kconfig' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a7345d648321a3d9b90d51dbc719