### PR TITLE
Fix strtol overflow handling

### DIFF
--- a/lib/libc/minimal/source/stdlib/strtol.c
+++ b/lib/libc/minimal/source/stdlib/strtol.c
@@ -47,6 +47,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 	register int c;
 	register unsigned long cutoff;
 	register int neg = 0, any, cutlim;
+	long result;
 
 	/*
 	 * Skip white space and pick up leading +/- sign if any.
@@ -115,14 +116,14 @@ long strtol(const char *nptr, char **endptr, register int base)
 	}
 
 	if (any < 0) {
-		acc = neg ? LONG_MIN : LONG_MAX;
+		result = neg ? LONG_MIN : LONG_MAX;
 		errno = ERANGE;
-	} else if (neg != 0) {
-		acc = -acc;
+	} else {
+		result = neg ? -((long)acc) : (long)acc;
 	}
 
 	if (endptr != NULL) {
 		*endptr = (char *)(any ? (s - 1) : nptr);
 	}
-	return acc;
+	return result;
 }


### PR DESCRIPTION
## Summary
- fix integer handling in minimal libc strtol

## Testing
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: drivers/i2c/target/Kconfig not found)*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: drivers/i2c/target/Kconfig not found)*
- `west build -p auto -b native_posix samples/hello_world` *(fails: Invalid BOARD)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: drivers/i2c/target/Kconfig not found)*


------
https://chatgpt.com/codex/tasks/task_e_6857a7d580d08321b053fc9eb519f771