### PR TITLE
Fix ring buffer space calculation

### DIFF
--- a/subsys/modem/modem_cmux.c
+++ b/subsys/modem/modem_cmux.c
@@ -272,7 +272,12 @@ static uint16_t modem_cmux_transmit_frame(struct modem_cmux *cmux,
 	uint16_t data_len;
 	uint16_t buf_idx;
 
-	space = ring_buf_space_get(&cmux->transmit_rb) - MODEM_CMUX_FRAME_SIZE_MAX;
+	space = ring_buf_space_get(&cmux->transmit_rb);
+	if (space > MODEM_CMUX_FRAME_SIZE_MAX) {
+		space -= MODEM_CMUX_FRAME_SIZE_MAX;
+	} else {
+		space = 0U;
+	}
 	data_len = MIN(space, frame->data_len);
 	data_len = MIN(data_len, CONFIG_MODEM_CMUX_MTU);
 


### PR DESCRIPTION
## Summary
- prevent potential underflow when calculating available space in CMUX frame transmission

## Testing
- `scripts/checkpatch.pl --no-tree -f subsys/modem/modem_cmux.c`
- `west build` *(fails: `west: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857a790c13c8321bd07fa446751ec69