### PR TITLE
Fix overflow in settings_zms_save

### DIFF
--- a/subsys/settings/src/settings_zms.c
+++ b/subsys/settings/src/settings_zms.c
@@ -432,7 +432,7 @@ static int settings_zms_save(struct settings_store *cs, const char *name, const 
 
 	for (int i = 0; i <= cf->hash_collision_num; i++) {
 		rc = zms_read(&cf->cf_zms, name_hash + i * LSB_GET(ZMS_COLLISIONS_MASK), &rdname,
-			      sizeof(rdname));
+			      sizeof(rdname) - 1);
 		if (rc == -ENOENT) {
 			if (first_available_hash_index < 0) {
 				first_available_hash_index = i;
@@ -445,6 +445,9 @@ static int settings_zms_save(struct settings_store *cs, const char *name, const 
 		/* Settings entry exist, let's verify if this is the same
 		 * name
 		 */
+		if (rc >= sizeof(rdname)) {
+			rc = sizeof(rdname) - 1;
+		}
 		rdname[rc] = '\0';
 		if ((rc == name_len) && !memcmp(name, rdname, rc)) {
 			/* Hash exist and the names are equal, we should


### PR DESCRIPTION
## Summary
- fix possible overflow when null terminating rdname buffer

## Testing
- `./scripts/checkpatch.pl --no-tree -f subsys/settings/src/settings_zms.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: west: unknown command "build")*

------
https://chatgpt.com/codex/tasks/task_e_6857a74b8cd48321964e6af88cbb05a4