### PR TITLE
Fix uninitialized format in ov9655

### DIFF
--- a/drivers/video/ov9655.c
+++ b/drivers/video/ov9655.c
@@ -326,7 +326,7 @@ static int ov9655_get_fmt(const struct device *dev, struct video_format *fmt)
 static int ov9655_init(const struct device *dev)
 {
 	const struct ov9655_config *config = dev->config;
-	struct video_format fmt;
+	struct video_format fmt = { 0 };
 	uint32_t pid;
 	int ret;
 
@@ -381,9 +381,11 @@ static int ov9655_init(const struct device *dev)
 	}
 
 	/* Set default camera format (QQVGA, YUYV) */
+	fmt.type = VIDEO_BUF_TYPE_OUTPUT;
 	fmt.pixelformat = VIDEO_PIX_FMT_YUYV;
 	fmt.width = 160;
 	fmt.height = 120;
+	fmt.pitch = fmt.width * video_bits_per_pixel(fmt.pixelformat) / BITS_PER_BYTE;
 
 	return ov9655_set_fmt(dev, &fmt);
 }


### PR DESCRIPTION
## Summary
- initialize `struct video_format` in `ov9655_init`

## Testing
- `scripts/checkpatch.pl --no-tree -f drivers/video/ov9655.c`
- `west --version`
- `west init -l .`
- `west update` *(fails: huge download, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6857a749a4d88321bf06ef4094619a82