### PR TITLE
Fix shift width for bma4xx emulator

### DIFF
--- a/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
+++ b/drivers/sensor/bosch/bma4xx/bma4xx_emul.c
@@ -203,7 +203,7 @@ void bma4xx_emul_set_accel_data(const struct emul *target, q31_t value, int8_t s
 	int16_t reg_val;
 
 	/* 0x00 -> +/-2g; 0x01 -> +/-4g; 0x02 -> +/-8g; 0x03 -> +/- 16g; */
-	int64_t accel_range = (2 << data->regs[BMA4XX_REG_ACCEL_RANGE]);
+int64_t accel_range = 2LL << data->regs[BMA4XX_REG_ACCEL_RANGE];
 
 	unshifted = shift < 0 ? ((int64_t)value >> -shift) : ((int64_t)value << shift);
 


### PR DESCRIPTION
## Summary
- fix left shift width when computing `accel_range`

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/sensor/bosch/bma4xx/bma4xx_emul.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: unknown command "build")*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: unknown command "build")*
- `west build -p auto -b native_posix samples/hello_world` *(fails: unknown command "build")*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: unknown command "build")*
- `west build -t run` *(fails: unknown command "build")*

------
https://chatgpt.com/codex/tasks/task_e_6857a7d2754c832199b142d1051bd1e2