### PR TITLE
Fix return type in paj7620_get_hw_id

### DIFF
--- a/drivers/sensor/pixart/paj7620/paj7620.c
+++ b/drivers/sensor/pixart/paj7620/paj7620.c
@@ -48,7 +48,7 @@ static int paj7620_select_register_bank(const struct device *dev, enum paj7620_m
 
 static int paj7620_get_hw_id(const struct device *dev, uint16_t *result)
 {
-	uint8_t ret;
+	int ret;
 	uint8_t hw_id[2];
 	const struct paj7620_config *config = dev->config;
 


### PR DESCRIPTION
## Summary
- fix truncated error codes in `paj7620_get_hw_id`

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/sensor/pixart/paj7620/paj7620.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: command exited with status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6857b51b95c0832190bb7a29c89cb169