### PR TITLE
Fix volume shift in TLV320DAC driver

### DIFF
--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -443,9 +443,11 @@ static int codec_set_output_volume(const struct device *dev, int vol)
 	};
 
 	if ((vol > CODEC_OUTPUT_VOLUME_MAX) ||
-			(vol < CODEC_OUTPUT_VOLUME_MIN)) {
+	    (vol < CODEC_OUTPUT_VOLUME_MIN)) {
+		int vol_abs = abs(vol);
+
 		LOG_ERR("Invalid volume %d.%d dB",
-				vol >> 1, ((uint32_t)vol & 1) ? 5 : 0);
+			vol_abs >> 1, (vol_abs & 1) ? 5 : 0);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
## Summary
- avoid shifting negative value when logging invalid volume

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/audio/tlv320dac310x.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: unknown command)*

------
https://chatgpt.com/codex/tasks/task_e_6857b51deb68832183656aa98c0ae7e6