### PR TITLE
Fix dead code warning in tlv320dac310x driver

### DIFF
--- a/drivers/audio/tlv320dac310x.c
+++ b/drivers/audio/tlv320dac310x.c
@@ -326,8 +326,11 @@ static int codec_configure_clocks(const struct device *dev,
 			return -EINVAL;
 		}
 		LOG_DBG("I2S Master BCLKDIV: %u", bclk_div);
-		codec_write_reg(dev, BCLK_DIV_ADDR,
-				BCLK_DIV_POWER_UP | BCLK_DIV(bclk_div));
+	/*
+	* BCLK divider register will be written after the DAC and
+	* modulator clocks are configured. Writing it here would
+	* be redundant as the register is programmed again below.
+	*/
 	}
 
 	/* set NDAC, then MDAC, followed by OSR */


### PR DESCRIPTION
## Summary
- remove redundant early write of BCLK divider
- add a comment explaining that the register is written later

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/audio/tlv320dac310x.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: command not found)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: command not found)*
- `make html` in `doc/` *(fails: missing Doxygen)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6eb05d88321b4c8909d2433b97f