### PR TITLE
Fix gain range check in apds9253 driver

### DIFF
--- a/drivers/sensor/apds9253/apds9253.c
+++ b/drivers/sensor/apds9253/apds9253.c
@@ -14,6 +14,7 @@
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/logging/log.h>
 
 #include "apds9253.h"
@@ -131,12 +132,12 @@ static int apds9253_attr_set_gain(const struct device *dev, uint8_t gain)
 		return 0;
 	}
 
-	static uint8_t value_map[] = {
+	static const uint8_t value_map[] = {
 		APDS9253_LS_GAIN_RANGE_1, APDS9253_LS_GAIN_RANGE_3,  APDS9253_LS_GAIN_RANGE_6,
 		APDS9253_LS_GAIN_RANGE_9, APDS9253_LS_GAIN_RANGE_18,
 	};
 
-	if (gain < APDS9253_LS_GAIN_RANGE_1 || gain > APDS9253_LS_GAIN_RANGE_18) {
+	if (gain >= ARRAY_SIZE(value_map)) {
 		return -EINVAL;
 	}
 	value = value_map[gain];


### PR DESCRIPTION
## Summary
- include util headers for ARRAY_SIZE
- clamp apds9253 gain setting to valid range

## Testing
- `scripts/checkpatch.pl --no-tree -f drivers/sensor/apds9253/apds9253.c`
- ⚠️ `west build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6857b49dfe5083219934a3b224ec49fb