### PR TITLE
Fix memory corruption in mcp7940n write helper

### DIFF
--- a/drivers/counter/rtc_mcp7940n.c
+++ b/drivers/counter/rtc_mcp7940n.c
@@ -276,13 +276,26 @@ static int write_data_block(const struct device *dev, enum mcp7940n_register add
 		return -EINVAL;
 	}
 
-	if (addr == REG_RTC_SEC) {
+	switch (addr) {
+	case REG_RTC_SEC:
+		if (size != RTC_TIME_REGISTERS_SIZE) {
+			return -EINVAL;
+		}
 		write_block_start = (uint8_t *)&data->registers;
-	} else if (addr == REG_ALM0_SEC) {
+		break;
+	case REG_ALM0_SEC:
+		if (size != RTC_ALARM_REGISTERS_SIZE) {
+			return -EINVAL;
+		}
 		write_block_start = (uint8_t *)&data->alm0_registers;
-	} else if (addr == REG_ALM1_SEC) {
+		break;
+	case REG_ALM1_SEC:
+		if (size != RTC_ALARM_REGISTERS_SIZE) {
+			return -EINVAL;
+		}
 		write_block_start = (uint8_t *)&data->alm1_registers;
-	} else {
+		break;
+	default:
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
## Summary
- validate size parameter in `write_data_block` to prevent overrun

## Testing
- `./scripts/checkpatch.pl --no-tree -f drivers/counter/rtc_mcp7940n.c`
- `west build -p auto -b qemu_x86 samples/hello_world` *(fails: command not found)*
- `west build -p auto -b qemu_cortex_m3 samples/hello_world` *(fails: command not found)*
- `west build -p auto -b native_posix samples/hello_world` *(fails: command not found)*
- `west build -p auto -b qemu_x86 tests/kernel/common` *(fails: command not found)*
- `west build -t run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bc3001748321a1c645777d30da8b